### PR TITLE
v2 redesign — Phase 5: tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [2.0.0-alpha.4] — 2026-04-26
+
+### Added
+- **JSON IR export (`exportJson`)** (`src/tools/export-json.ts`): serialises a `CompositionIR` to JSON with optional pretty-printing and source-span inclusion.
+- **Canonical source formatter (`format`)** (`src/tools/format.ts`): reformats SynthJS source to a canonical style (consistent indentation, normalised whitespace, version hoisting).
+- **MIDI export (`exportMidi`)** (`src/tools/export-midi.ts`): converts a `CompositionIR` to a standard MIDI file (`Uint8Array`) with tempo, program-change, and note-on/note-off events.
+- **WAV offline render (`renderToWav`, `audioBufferToWav`)** (`src/tools/render-wav.ts`): offline Web Audio rendering of a composition to a 44.1 kHz PCM WAV buffer.
+- **Doc generator (`generateDocs`)** (`src/tools/gen-docs.ts`): extracts `///` doc comments from bindings, voices, and instrument definitions and emits a Markdown reference page.
+- **Hot reload (`Composition.update`)** (`src/runtime/composition.ts`): replaces the active `CompositionIR` mid-playback, rescheduling voices from the current transport position.
+- **`synth` CLI binary** (`src/cli/main.ts`): command-line interface with subcommands:
+  - `fmt [path] [-i]` — format source in-place or to stdout
+  - `check [path]` — parse and compile, exit 1 on errors
+  - `json [path] [--include-spans] [--compact]` — emit IR as JSON
+  - `midi <input> -o <output>` — export to MIDI file
+  - `doc [path] [--title T] [-o <output>]` — generate Markdown docs
+  - `help` — display usage
+
 ## [2.0.0-alpha.3] — 2026-04-26
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
       "require": "./dist/index.cjs"
     }
   },
+  "bin": {
+    "synth": "./dist/cli.js"
+  },
   "files": [
     "dist",
     "README.md",
@@ -24,6 +27,7 @@
     "typecheck": "tsc --noEmit",
     "lint": "biome check src",
     "format": "biome format --write src",
+    "pretest": "pnpm build",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage"

--- a/src/cli/main.test.ts
+++ b/src/cli/main.test.ts
@@ -1,0 +1,143 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const cliPath = join(__dirname, "../../dist/cli.js");
+
+const runCli = (
+  args: string[],
+  stdin?: string,
+): { stdout: string; stderr: string; status: number } => {
+  if (!existsSync(cliPath)) {
+    throw new Error(`CLI not built. Run 'pnpm build' first. Path: ${cliPath}`);
+  }
+  try {
+    const stdout = execFileSync("node", [cliPath, ...args], {
+      encoding: "utf8",
+      ...(stdin !== undefined ? { input: stdin } : {}),
+    });
+    return { stdout, stderr: "", status: 0 };
+  } catch (e) {
+    const err = e as { status: number; stdout: string; stderr: string };
+    return {
+      stdout: err.stdout?.toString() ?? "",
+      stderr: err.stderr?.toString() ?? "",
+      status: err.status ?? 1,
+    };
+  }
+};
+
+const cliAvailable = existsSync(cliPath);
+
+describe.skipIf(!cliAvailable)("CLI — help", () => {
+  it("no args prints help", () => {
+    const { stdout, status } = runCli([]);
+    expect(status).toBe(0);
+    expect(stdout).toContain("synth");
+    expect(stdout).toContain("COMMANDS:");
+  });
+
+  it("help subcommand prints help", () => {
+    const { stdout, status } = runCli(["help"]);
+    expect(status).toBe(0);
+    expect(stdout).toContain("COMMANDS:");
+  });
+
+  it("--help flag prints help", () => {
+    const { stdout, status } = runCli(["--help"]);
+    expect(status).toBe(0);
+    expect(stdout).toContain("COMMANDS:");
+  });
+});
+
+describe.skipIf(!cliAvailable)("CLI — fmt", () => {
+  it("formats stdin to stdout", () => {
+    const { stdout, status } = runCli(["fmt"], "4 c4");
+    expect(status).toBe(0);
+    expect(stdout).toContain("4 c4");
+  });
+
+  it("formats file to stdout", () => {
+    const dir = mkdtempSync(join(tmpdir(), "synth-test-"));
+    const path = join(dir, "in.synth");
+    writeFileSync(path, "4 c4 d4");
+    const { stdout, status } = runCli(["fmt", path]);
+    expect(status).toBe(0);
+    expect(stdout).toContain("4 c4 d4");
+  });
+
+  it("-i writes back to file", () => {
+    const dir = mkdtempSync(join(tmpdir(), "synth-test-"));
+    const path = join(dir, "in.synth");
+    writeFileSync(path, "4 c4 d4");
+    runCli(["fmt", "-i", path]);
+    const result = readFileSync(path, "utf8");
+    expect(result).toContain("4 c4 d4");
+  });
+});
+
+describe.skipIf(!cliAvailable)("CLI — check", () => {
+  it("exits 0 on valid source", () => {
+    const { status } = runCli(["check"], "4 c4");
+    expect(status).toBe(0);
+  });
+
+  it("exits 1 on invalid source", () => {
+    const { status, stderr } = runCli(["check"], "4 ,");
+    expect(status).toBe(1);
+    expect(stderr).toContain("ParseError");
+  });
+});
+
+describe.skipIf(!cliAvailable)("CLI — json", () => {
+  it("emits valid JSON", () => {
+    const { stdout, status } = runCli(["json"], "4 c4");
+    expect(status).toBe(0);
+    expect(() => JSON.parse(stdout)).not.toThrow();
+  });
+
+  it("--compact removes whitespace", () => {
+    const { stdout } = runCli(["json", "--compact"], "4 c4");
+    expect(stdout.split("\n").length).toBeLessThan(5);
+  });
+});
+
+describe.skipIf(!cliAvailable)("CLI — midi", () => {
+  it("writes MIDI bytes to file", () => {
+    const dir = mkdtempSync(join(tmpdir(), "synth-test-"));
+    const inPath = join(dir, "in.synth");
+    const outPath = join(dir, "out.mid");
+    writeFileSync(inPath, "4 c4");
+    const { status } = runCli(["midi", inPath, "-o", outPath]);
+    expect(status).toBe(0);
+    const bytes = readFileSync(outPath);
+    expect(bytes.length).toBeGreaterThan(0);
+    expect(bytes.subarray(0, 4).toString()).toBe("MThd");
+  });
+
+  it("requires -o", () => {
+    const { status } = runCli(["midi"], "4 c4");
+    expect(status).toBe(2);
+  });
+});
+
+describe.skipIf(!cliAvailable)("CLI — doc", () => {
+  it("emits markdown to stdout", () => {
+    const src = "/// my motif\nintro = 4 c4";
+    const { stdout, status } = runCli(["doc"], src);
+    expect(status).toBe(0);
+    expect(stdout).toContain("intro");
+  });
+});
+
+describe.skipIf(!cliAvailable)("CLI — unknown command", () => {
+  it("exits 2", () => {
+    const { status, stderr } = runCli(["nonexistent"]);
+    expect(status).toBe(2);
+    expect(stderr).toContain("unknown command");
+  });
+});

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,0 +1,183 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import {
+  LexError,
+  ParseError,
+  ResolveError,
+  ValidationError,
+  compileSync,
+  exportJson,
+  exportMidi,
+  format,
+  formatError,
+  generateDocs,
+} from "../index.js";
+
+function readInput(path?: string): string {
+  if (!path || path === "-") {
+    return readFileSync(0, "utf8"); // 0 = stdin fd
+  }
+  return readFileSync(path, "utf8");
+}
+
+function tryCompile(source: string, sourceLabel: string): ReturnType<typeof compileSync> | null {
+  try {
+    return compileSync(source);
+  } catch (e) {
+    if (
+      e instanceof LexError ||
+      e instanceof ParseError ||
+      e instanceof ResolveError ||
+      e instanceof ValidationError
+    ) {
+      process.stderr.write(`${formatError(e, source)}\n`);
+      return null;
+    }
+    process.stderr.write(`unexpected error in ${sourceLabel}: ${(e as Error).message}\n`);
+    return null;
+  }
+}
+
+function runFmt(args: string[]): number {
+  let inPlace = false;
+  let path: string | undefined;
+  for (const a of args) {
+    if (a === "-i") inPlace = true;
+    else if (!a.startsWith("-")) path = a;
+  }
+  const source = readInput(path);
+  let formatted: string;
+  try {
+    formatted = format(source);
+  } catch (e) {
+    process.stderr.write(`format failed: ${(e as Error).message}\n`);
+    return 1;
+  }
+  if (inPlace) {
+    if (!path || path === "-") {
+      process.stderr.write("--in-place requires a file path\n");
+      return 2;
+    }
+    writeFileSync(path, formatted);
+  } else {
+    process.stdout.write(formatted);
+  }
+  return 0;
+}
+
+function runCheck(args: string[]): number {
+  const path = args.find((a) => !a.startsWith("-"));
+  const source = readInput(path);
+  const ir = tryCompile(source, path ?? "stdin");
+  if (!ir) return 1;
+  for (const d of ir.diagnostics) {
+    process.stderr.write(
+      `${d.severity}: ${d.message} at line ${d.span.line}, col ${d.span.column}\n`,
+    );
+  }
+  return 0;
+}
+
+function runJson(args: string[]): number {
+  const includeSpans = args.includes("--include-spans");
+  const compact = args.includes("--compact");
+  const path = args.find((a) => !a.startsWith("-"));
+  const source = readInput(path);
+  const ir = tryCompile(source, path ?? "stdin");
+  if (!ir) return 1;
+  process.stdout.write(`${exportJson(ir, { pretty: !compact, includeSpans })}\n`);
+  return 0;
+}
+
+function runMidi(args: string[]): number {
+  let outPath: string | undefined;
+  let inPath: string | undefined;
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "-o") {
+      outPath = args[i + 1];
+      i++;
+    } else if (!args[i]?.startsWith("-")) {
+      inPath = args[i];
+    }
+  }
+  if (!outPath) {
+    process.stderr.write("midi: -o <output> required\n");
+    return 2;
+  }
+  const source = readInput(inPath);
+  const ir = tryCompile(source, inPath ?? "stdin");
+  if (!ir) return 1;
+  const bytes = exportMidi(ir);
+  writeFileSync(outPath, bytes);
+  return 0;
+}
+
+function runDoc(args: string[]): number {
+  let title: string | undefined;
+  let outPath: string | undefined;
+  let inPath: string | undefined;
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--title") {
+      title = args[i + 1];
+      i++;
+    } else if (args[i] === "-o") {
+      outPath = args[i + 1];
+      i++;
+    } else if (!args[i]?.startsWith("-")) inPath = args[i];
+  }
+  const source = readInput(inPath);
+  const md = generateDocs(source, title !== undefined ? { title } : {});
+  if (outPath) writeFileSync(outPath, md);
+  else process.stdout.write(md);
+  return 0;
+}
+
+function printHelp(): number {
+  process.stdout.write(`synth — SynthJS CLI
+
+USAGE:
+  synth <command> [args]
+
+COMMANDS:
+  fmt [path] [-i]            Format source. Reads stdin if no path. -i writes back to file.
+  check [path]               Parse + compile. Exits 1 on errors.
+  json [path] [--include-spans] [--compact]
+                             Emit CompositionIR as JSON.
+  midi <input> -o <output>   Export to MIDI file.
+  doc [path] [--title T] [-o <output>]
+                             Generate Markdown docs from /// comments.
+  help                       Show this help.
+`);
+  return 0;
+}
+
+const args = process.argv.slice(2);
+const cmd = args[0];
+
+let exitCode: number;
+switch (cmd) {
+  case "fmt":
+    exitCode = runFmt(args.slice(1));
+    break;
+  case "check":
+    exitCode = runCheck(args.slice(1));
+    break;
+  case "json":
+    exitCode = runJson(args.slice(1));
+    break;
+  case "midi":
+    exitCode = runMidi(args.slice(1));
+    break;
+  case "doc":
+    exitCode = runDoc(args.slice(1));
+    break;
+  case "help":
+  case "--help":
+  case undefined:
+    exitCode = printHelp();
+    break;
+  default:
+    process.stderr.write(`unknown command '${cmd}'. Run 'synth help'.\n`);
+    exitCode = 2;
+}
+
+process.exit(exitCode);

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,3 +118,11 @@ export {
 } from "./runtime/composition.js";
 export type { AudioContextLike, AudioNodeLike, AudioParamLike } from "./runtime/audio-context.js";
 export { MockAudioContext } from "./runtime/mock-audio-context.js"; // useful for users writing tests
+
+// WAV offline render
+export {
+  audioBufferToWav,
+  renderToWav,
+  type OfflineAudioContextLike,
+  type RenderOptions,
+} from "./tools/render-wav.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,6 +106,7 @@ export type {
 
 // Tools
 export { exportJson, type JsonExportOptions } from "./tools/export-json.js";
+export { exportMidi } from "./tools/export-midi.js";
 export { generateDocs, type GenDocsOptions } from "./tools/gen-docs.js";
 export { format } from "./tools/format.js";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,6 +107,7 @@ export type {
 // Tools
 export { exportJson, type JsonExportOptions } from "./tools/export-json.js";
 export { generateDocs, type GenDocsOptions } from "./tools/gen-docs.js";
+export { format } from "./tools/format.js";
 
 // Runtime API
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,6 +104,10 @@ export type {
   Diagnostic,
 } from "./ir/nodes.js";
 
+// Tools
+export { exportJson, type JsonExportOptions } from "./tools/export-json.js";
+export { generateDocs, type GenDocsOptions } from "./tools/gen-docs.js";
+
 // Runtime API
 export {
   Composition,

--- a/src/runtime/composition.test.ts
+++ b/src/runtime/composition.test.ts
@@ -422,3 +422,108 @@ describe("Composition — ended event", () => {
     expect(fired).toHaveLength(0);
   });
 });
+
+describe("Composition — update (hot reload)", () => {
+  it("update before play swaps IR and leaves state as idle", async () => {
+    const ctx = new MockAudioContext();
+    const ir1 = irOf([noteEvent({ frequencies: [440] })]);
+    const comp = new Composition(ir1, { audioContext: ctx });
+    expect(comp.state).toBe("idle");
+
+    const ir2 = irOf([noteEvent({ frequencies: [880] })]);
+    await comp.update(ir2);
+
+    expect(comp.state).toBe("idle");
+    // The ir field reflects the new IR (accessed through diagnostics as a proxy check)
+    // We verify via a play that schedules the new events
+    await comp.play();
+    // The oscillator count should be 1 (from the new IR)
+    expect(ctx.history.filter((h) => h.method === "createOscillator")).toHaveLength(1);
+  });
+
+  it("ir field reflects new IR after update (idle state)", async () => {
+    const ctx = new MockAudioContext();
+    const ir1: CompositionIR = {
+      tempo: 60,
+      timeSig: { numerator: 4, denominator: 4 },
+      voices: [],
+      diagnostics: [{ message: "old", severity: "warning", span }],
+    };
+    const comp = new Composition(ir1, { audioContext: ctx });
+
+    const ir2: CompositionIR = {
+      tempo: 120,
+      timeSig: { numerator: 4, denominator: 4 },
+      voices: [],
+      diagnostics: [{ message: "new", severity: "warning", span }],
+    };
+    await comp.update(ir2);
+
+    // diagnostics getter reads from this.ir
+    expect(comp.diagnostics[0]?.message).toBe("new");
+  });
+
+  it("update during play resets players and schedules new IR events", async () => {
+    const ctx = new MockAudioContext();
+    const ir1 = irOf([noteEvent({ startBeat: 0 }), noteEvent({ startBeat: 0.25 })]);
+    const comp = new Composition(ir1, { audioContext: ctx });
+    await comp.play();
+    const oscCountAfterPlay = ctx.history.filter((h) => h.method === "createOscillator").length;
+    expect(oscCountAfterPlay).toBe(2);
+
+    const ir2 = irOf([noteEvent({ startBeat: 0 }), noteEvent({ startBeat: 0.25 }), noteEvent({ startBeat: 0.5 })]);
+    await comp.update(ir2);
+
+    // After update, new oscillators are scheduled for new IR events
+    const oscCountAfterUpdate = ctx.history.filter((h) => h.method === "createOscillator").length;
+    expect(oscCountAfterUpdate).toBeGreaterThan(oscCountAfterPlay);
+    expect(comp.state).toBe("playing");
+  });
+
+  it("update with empty new IR clears players", async () => {
+    const ctx = new MockAudioContext();
+    const ir1 = irOf([noteEvent(), noteEvent({ startBeat: 0.25 })]);
+    const comp = new Composition(ir1, { audioContext: ctx });
+    await comp.play();
+
+    const emptyIR: CompositionIR = {
+      tempo: 60,
+      timeSig: { numerator: 4, denominator: 4 },
+      voices: [],
+      diagnostics: [],
+    };
+    await comp.update(emptyIR);
+
+    // No new oscillators after update with empty IR
+    const oscCount = ctx.history.filter((h) => h.method === "createOscillator").length;
+    // All previously scheduled oscillators were stopped and no new ones added
+    expect(comp.state).toBe("playing");
+    // The diagnostics now come from the empty IR
+    expect(comp.diagnostics).toHaveLength(0);
+    // oscCount is stable: no extra oscillators scheduled from empty IR
+    const oscCountAfter = ctx.history.filter((h) => h.method === "createOscillator").length;
+    expect(oscCountAfter).toBe(oscCount);
+  });
+
+  it("update while paused swaps IR and reschedules from current beat", async () => {
+    const ctx = new MockAudioContext();
+    const ir1 = irOf([noteEvent({ startBeat: 0 })]);
+    const comp = new Composition(ir1, { audioContext: ctx });
+    await comp.play();
+    await comp.pause();
+    expect(comp.state).toBe("paused");
+
+    const ir2: CompositionIR = {
+      tempo: 60,
+      timeSig: { numerator: 4, denominator: 4 },
+      voices: [],
+      diagnostics: [{ message: "paused-update", severity: "warning", span }],
+    };
+    await comp.update(ir2);
+
+    // ir field updated
+    expect(comp.diagnostics[0]?.message).toBe("paused-update");
+    // state still paused (update doesn't change state)
+    expect(comp.state).toBe("paused");
+  });
+});

--- a/src/runtime/composition.test.ts
+++ b/src/runtime/composition.test.ts
@@ -471,7 +471,11 @@ describe("Composition — update (hot reload)", () => {
     const oscCountAfterPlay = ctx.history.filter((h) => h.method === "createOscillator").length;
     expect(oscCountAfterPlay).toBe(2);
 
-    const ir2 = irOf([noteEvent({ startBeat: 0 }), noteEvent({ startBeat: 0.25 }), noteEvent({ startBeat: 0.5 })]);
+    const ir2 = irOf([
+      noteEvent({ startBeat: 0 }),
+      noteEvent({ startBeat: 0.25 }),
+      noteEvent({ startBeat: 0.5 }),
+    ]);
     await comp.update(ir2);
 
     // After update, new oscillators are scheduled for new IR events

--- a/src/runtime/composition.ts
+++ b/src/runtime/composition.ts
@@ -25,6 +25,7 @@ export class Composition {
   private readonly setTimeoutFn: (cb: () => void, ms: number) => unknown;
   private readonly clearTimeoutFn: (handle: unknown) => void;
   private endedListeners: ((info: { totalDurationSec: number }) => void)[] = [];
+  private playStartTime = 0;
 
   constructor(
     private readonly ir: CompositionIR,
@@ -94,6 +95,7 @@ export class Composition {
 
     const startOffset = 0.05; // small lead time for setup
     const voiceStartTime = this.ctx.currentTime + startOffset;
+    this.playStartTime = voiceStartTime;
     const fromBeat = opts.from ?? 0;
 
     this.scheduleIteration(voiceStartTime, fromBeat);
@@ -148,6 +150,26 @@ export class Composition {
     for (const player of this.players) player.stop();
     this.players.length = 0;
     this._state = "stopped";
+  }
+
+  async update(newIR: CompositionIR): Promise<void> {
+    if (this._state !== "playing" && this._state !== "paused") {
+      // Just swap; no need to reschedule
+      (this as unknown as { ir: CompositionIR }).ir = newIR;
+      return;
+    }
+    // Compute current beat from elapsed audio time
+    const elapsedSec = this.ctx.currentTime - this.playStartTime;
+    const tempo = this.ir.tempo;
+    const currentBeat = elapsedSec / (4 * (60 / tempo));
+    // Stop active players
+    for (const player of this.players) player.stop();
+    this.players.length = 0;
+    // Swap IR (use unknown cast to bypass readonly)
+    (this as unknown as { ir: CompositionIR }).ir = newIR;
+    // Re-anchor: reschedule from the *new* IR starting at the current beat
+    // (events with startBeat < currentBeat are skipped by scheduleIteration's filter)
+    this.scheduleIteration(this.ctx.currentTime + 0.05, currentBeat);
   }
 
   onEnded(listener: (info: { totalDurationSec: number }) => void): () => void {

--- a/src/tools/export-json.test.ts
+++ b/src/tools/export-json.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import type { CompositionIR, InstrumentSpec, TimelineEvent } from "../ir/nodes.js";
+import { exportJson } from "./export-json.js";
+
+const span = { start: 0, end: 0, line: 1, column: 1 };
+const sineInstrument: InstrumentSpec = { name: "sine", oscillator: "sine" };
+
+const noteEvent = (over: Partial<TimelineEvent> = {}): TimelineEvent => ({
+  startBeat: 0,
+  durationBeats: 0.25,
+  frequencies: [440],
+  gain: 0.65,
+  articulation: [],
+  fxChain: [],
+  instrument: sineInstrument,
+  annotations: [],
+  span,
+  ...over,
+});
+
+const emptyIR = (): CompositionIR => ({
+  tempo: 120,
+  timeSig: { numerator: 4, denominator: 4 },
+  voices: [],
+  diagnostics: [],
+});
+
+const irWithVoice = (): CompositionIR => ({
+  tempo: 120,
+  timeSig: { numerator: 4, denominator: 4 },
+  voices: [{ name: "main", events: [noteEvent()] }],
+  diagnostics: [],
+});
+
+describe("exportJson — empty IR", () => {
+  it("serializes an empty IR (no voices)", () => {
+    const result = exportJson(emptyIR());
+    const parsed = JSON.parse(result) as CompositionIR;
+    expect(parsed.tempo).toBe(120);
+    expect(parsed.voices).toEqual([]);
+    expect(parsed.diagnostics).toEqual([]);
+  });
+});
+
+describe("exportJson — voice with events", () => {
+  it("serializes IR with one voice including frequencies and gain", () => {
+    const result = exportJson(irWithVoice());
+    const parsed = JSON.parse(result) as CompositionIR;
+    expect(parsed.voices).toHaveLength(1);
+    const voice = parsed.voices[0];
+    expect(voice).toBeDefined();
+    expect(voice?.name).toBe("main");
+    expect(voice?.events).toHaveLength(1);
+    const event = voice?.events[0];
+    expect(event).toBeDefined();
+    expect(event?.frequencies).toEqual([440]);
+    expect(event?.gain).toBe(0.65);
+  });
+});
+
+describe("exportJson — spans", () => {
+  it("omits spans by default", () => {
+    const result = exportJson(irWithVoice());
+    const parsed = JSON.parse(result) as Record<string, unknown>;
+    const voices = parsed.voices as Array<{ events: Array<Record<string, unknown>> }>;
+    const event = (voices[0]?.events ?? [])[0] as Record<string, unknown> | undefined;
+    expect(event?.span).toBeUndefined();
+  });
+
+  it("preserves spans when includeSpans: true", () => {
+    const result = exportJson(irWithVoice(), { includeSpans: true });
+    const parsed = JSON.parse(result) as Record<string, unknown>;
+    const voices = parsed.voices as Array<{ events: Array<Record<string, unknown>> }>;
+    const event = (voices[0]?.events ?? [])[0] as Record<string, unknown> | undefined;
+    expect(event?.span).toBeDefined();
+  });
+});
+
+describe("exportJson — number precision", () => {
+  it("rounds numbers to precision 6 by default (0.30000000000001 → 0.3)", () => {
+    const ir = irWithVoice();
+    const firstEvent = ir.voices[0]?.events[0];
+    if (firstEvent) firstEvent.gain = 0.30000000000001;
+    const result = exportJson(ir);
+    const parsed = JSON.parse(result) as CompositionIR;
+    expect(parsed.voices[0]?.events[0]?.gain).toBe(0.3);
+  });
+});
+
+describe("exportJson — formatting", () => {
+  it("pretty output has newlines and indentation (default pretty: true)", () => {
+    const result = exportJson(emptyIR());
+    expect(result).toContain("\n");
+    expect(result).toContain("  ");
+  });
+
+  it("compact output with pretty: false has no newlines", () => {
+    const result = exportJson(emptyIR(), { pretty: false });
+    expect(result).not.toContain("\n");
+  });
+});
+
+describe("exportJson — determinism", () => {
+  it("produces identical output across multiple calls with the same input", () => {
+    const ir = irWithVoice();
+    const first = exportJson(ir);
+    const second = exportJson(ir);
+    const third = exportJson(ir);
+    expect(first).toBe(second);
+    expect(second).toBe(third);
+  });
+});

--- a/src/tools/export-json.ts
+++ b/src/tools/export-json.ts
@@ -1,0 +1,33 @@
+import type { CompositionIR } from "../ir/nodes.js";
+
+export type JsonExportOptions = {
+  pretty?: boolean;
+  includeSpans?: boolean;
+  precision?: number;
+};
+
+export function exportJson(ir: CompositionIR, opts: JsonExportOptions = {}): string {
+  const pretty = opts.pretty ?? true;
+  const includeSpans = opts.includeSpans ?? false;
+  const precision = opts.precision ?? 6;
+
+  const cleaned = clean(ir, { includeSpans, precision });
+  return pretty ? JSON.stringify(cleaned, null, 2) : JSON.stringify(cleaned);
+}
+
+function clean(value: unknown, opts: { includeSpans: boolean; precision: number }): unknown {
+  if (typeof value === "number") {
+    return Number(value.toFixed(opts.precision));
+  }
+  if (Array.isArray(value)) return value.map((v) => clean(v, opts));
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    const sortedKeys = Object.keys(value).sort();
+    for (const k of sortedKeys) {
+      if (k === "span" && !opts.includeSpans) continue;
+      out[k] = clean((value as Record<string, unknown>)[k], opts);
+    }
+    return out;
+  }
+  return value;
+}

--- a/src/tools/export-midi.test.ts
+++ b/src/tools/export-midi.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+import { compileSync } from "../index.js";
+import { exportMidi, vlq } from "./export-midi.js";
+
+describe("vlq encoding", () => {
+  it("0 -> [0x00]", () => {
+    expect(vlq(0)).toEqual([0x00]);
+  });
+  it("127 -> [0x7F]", () => {
+    expect(vlq(127)).toEqual([0x7f]);
+  });
+  it("128 -> [0x81, 0x00]", () => {
+    expect(vlq(128)).toEqual([0x81, 0x00]);
+  });
+  it("16383 -> [0xFF, 0x7F]", () => {
+    expect(vlq(16383)).toEqual([0xff, 0x7f]);
+  });
+  it("16384 -> [0x81, 0x80, 0x00]", () => {
+    expect(vlq(16384)).toEqual([0x81, 0x80, 0x00]);
+  });
+});
+
+describe("exportMidi — header", () => {
+  it("starts with MThd", () => {
+    const ir = compileSync("4 c4");
+    const bytes = exportMidi(ir);
+    expect(Array.from(bytes.slice(0, 4))).toEqual([0x4d, 0x54, 0x68, 0x64]);
+  });
+
+  it("declares header length 6", () => {
+    const ir = compileSync("4 c4");
+    const bytes = exportMidi(ir);
+    // Bytes 4-7: header length
+    expect(bytes[4]).toBe(0);
+    expect(bytes[5]).toBe(0);
+    expect(bytes[6]).toBe(0);
+    expect(bytes[7]).toBe(6);
+  });
+
+  it("format 1", () => {
+    const ir = compileSync("4 c4");
+    const bytes = exportMidi(ir);
+    expect(bytes[8]).toBe(0);
+    expect(bytes[9]).toBe(1);
+  });
+
+  it("ntracks = 1 voice + 1 conductor = 2", () => {
+    const ir = compileSync("4 c4");
+    const bytes = exportMidi(ir);
+    expect(bytes[10]).toBe(0);
+    expect(bytes[11]).toBe(2);
+  });
+
+  it("division 480", () => {
+    const ir = compileSync("4 c4");
+    const bytes = exportMidi(ir);
+    expect(bytes[12]).toBe(1);
+    expect(bytes[13]).toBe(0xe0); // 480 = 0x01E0
+  });
+});
+
+describe("exportMidi — tracks", () => {
+  it("conductor + 2 voices", () => {
+    const ir = compileSync("voice a { 4 c4 } voice b { 4 g4 }");
+    const bytes = exportMidi(ir);
+    expect(bytes[10]).toBe(0);
+    expect(bytes[11]).toBe(3); // 1 conductor + 2 voices
+  });
+
+  it("contains tempo meta event", () => {
+    const ir = compileSync("\\tempo 120\n4 c4");
+    const bytes = exportMidi(ir);
+    // Find 0xFF 0x51 0x03 in conductor track (after MThd + MTrk header = 14 + 8 = 22 + delta = 23)
+    let foundTempo = false;
+    for (let i = 0; i < bytes.length - 2; i++) {
+      if (bytes[i] === 0xff && bytes[i + 1] === 0x51 && bytes[i + 2] === 0x03) {
+        foundTempo = true;
+        break;
+      }
+    }
+    expect(foundTempo).toBe(true);
+  });
+
+  it("contains time signature meta", () => {
+    const ir = compileSync("\\time 4/4\n4 c4");
+    const bytes = exportMidi(ir);
+    let foundTs = false;
+    for (let i = 0; i < bytes.length - 2; i++) {
+      if (bytes[i] === 0xff && bytes[i + 1] === 0x58 && bytes[i + 2] === 0x04) {
+        foundTs = true;
+        break;
+      }
+    }
+    expect(foundTs).toBe(true);
+  });
+
+  it("contains note-on (0x9N) and note-off (0x8N)", () => {
+    const ir = compileSync("4 c4");
+    const bytes = exportMidi(ir);
+    let foundOn = false;
+    let foundOff = false;
+    for (const b of bytes) {
+      if ((b & 0xf0) === 0x90) foundOn = true;
+      if ((b & 0xf0) === 0x80) foundOff = true;
+    }
+    expect(foundOn).toBe(true);
+    expect(foundOff).toBe(true);
+  });
+});
+
+describe("exportMidi — frequency to MIDI pitch", () => {
+  it("a4 (440Hz) -> MIDI 69", () => {
+    const ir = compileSync("4 a4");
+    const bytes = exportMidi(ir);
+    // Find note-on, then read pitch byte
+    for (let i = 0; i < bytes.length - 2; i++) {
+      if (((bytes[i] ?? 0) & 0xf0) === 0x90) {
+        expect(bytes[i + 1]).toBe(69);
+        return;
+      }
+    }
+    expect.fail("No note-on found");
+  });
+
+  it("c4 (~261.6Hz) -> MIDI 60", () => {
+    const ir = compileSync("4 c4");
+    const bytes = exportMidi(ir);
+    for (let i = 0; i < bytes.length - 2; i++) {
+      if (((bytes[i] ?? 0) & 0xf0) === 0x90) {
+        expect(bytes[i + 1]).toBe(60);
+        return;
+      }
+    }
+    expect.fail("No note-on found");
+  });
+});
+
+describe("exportMidi — annotations", () => {
+  it("@midi_channel(2) routes to channel 1 (0-indexed)", () => {
+    const ir = compileSync("@midi_channel(2) voice melody { 4 c4 }");
+    const bytes = exportMidi(ir);
+    let found = false;
+    for (let i = 0; i < bytes.length; i++) {
+      if (bytes[i] === 0x91) {
+        found = true;
+        break;
+      } // 0x90 | 1
+    }
+    expect(found).toBe(true);
+  });
+
+  it("@midi_program emits program change", () => {
+    const ir = compileSync("@midi_program(56) voice melody { 4 c4 }");
+    const bytes = exportMidi(ir);
+    let found = false;
+    for (let i = 0; i < bytes.length - 1; i++) {
+      if (((bytes[i] ?? 0) & 0xf0) === 0xc0 && bytes[i + 1] === 56) {
+        found = true;
+        break;
+      }
+    }
+    expect(found).toBe(true);
+  });
+});
+
+describe("exportMidi — chord", () => {
+  it("emits multiple note-ons at same tick", () => {
+    const ir = compileSync("4 <c4 e4 g4>");
+    const bytes = exportMidi(ir);
+    let noteOnCount = 0;
+    for (const b of bytes) {
+      if ((b & 0xf0) === 0x90) noteOnCount++;
+    }
+    expect(noteOnCount).toBe(3);
+  });
+});

--- a/src/tools/export-midi.ts
+++ b/src/tools/export-midi.ts
@@ -1,0 +1,163 @@
+import type { AnnotationData, CompositionIR, TimelineEvent, VoiceTimeline } from "../ir/nodes.js";
+
+const PPQ = 480;
+
+export function exportMidi(ir: CompositionIR): Uint8Array {
+  const microsPerQuarter = Math.round(60_000_000 / ir.tempo);
+  const tracks: Uint8Array[] = [];
+  tracks.push(buildConductorTrack(microsPerQuarter, ir.timeSig.numerator, ir.timeSig.denominator));
+  for (const voice of ir.voices) {
+    tracks.push(buildVoiceTrack(voice));
+  }
+  return assembleSmf(1, tracks);
+}
+
+function assembleSmf(format: number, tracks: Uint8Array[]): Uint8Array {
+  const header = new Uint8Array(14);
+  header.set([0x4d, 0x54, 0x68, 0x64], 0); // "MThd"
+  writeUint32(header, 4, 6); // length = 6
+  writeUint16(header, 8, format);
+  writeUint16(header, 10, tracks.length);
+  writeUint16(header, 12, PPQ);
+
+  let totalLen = header.length;
+  for (const t of tracks) totalLen += t.length;
+  const out = new Uint8Array(totalLen);
+  out.set(header, 0);
+  let offset = header.length;
+  for (const t of tracks) {
+    out.set(t, offset);
+    offset += t.length;
+  }
+  return out;
+}
+
+function buildConductorTrack(
+  microsPerQuarter: number,
+  timeSigNum: number,
+  timeSigDenom: number,
+): Uint8Array {
+  const events: number[] = [];
+  // delta = 0, tempo meta
+  events.push(0); // delta
+  events.push(0xff, 0x51, 0x03);
+  events.push(
+    (microsPerQuarter >> 16) & 0xff,
+    (microsPerQuarter >> 8) & 0xff,
+    microsPerQuarter & 0xff,
+  );
+  // time signature meta
+  events.push(0); // delta
+  events.push(0xff, 0x58, 0x04);
+  const denomPow = Math.round(Math.log2(timeSigDenom));
+  events.push(timeSigNum, denomPow, 24, 8);
+  // end of track
+  events.push(0); // delta
+  events.push(0xff, 0x2f, 0x00);
+
+  return wrapTrack(new Uint8Array(events));
+}
+
+function buildVoiceTrack(voice: VoiceTimeline): Uint8Array {
+  const channel = getMidiChannel(voice.events) ?? 0;
+  const program = getMidiProgram(voice.events);
+
+  type AbsEvent = { tick: number; bytes: number[] };
+  const absEvents: AbsEvent[] = [];
+
+  if (program !== undefined) {
+    absEvents.push({ tick: 0, bytes: [0xc0 | channel, program] });
+  }
+
+  for (const ev of voice.events) {
+    const startTick = Math.round(ev.startBeat * 4 * PPQ);
+    const durationTick = Math.round(ev.durationBeats * 4 * PPQ);
+    if (ev.frequencies.length === 0) continue; // rest
+    const eventChannel = annotationOverrideChannel(ev.annotations) ?? channel;
+    const velocity = Math.max(1, Math.min(127, Math.round(ev.gain * 127)));
+
+    for (const freq of ev.frequencies) {
+      const pitch = Math.round(69 + 12 * Math.log2(freq / 440));
+      const safePitch = Math.max(0, Math.min(127, pitch));
+      absEvents.push({ tick: startTick, bytes: [0x90 | eventChannel, safePitch, velocity] });
+      absEvents.push({
+        tick: startTick + durationTick,
+        bytes: [0x80 | eventChannel, safePitch, 0],
+      });
+    }
+  }
+
+  // Sort by tick
+  absEvents.sort((a, b) => a.tick - b.tick);
+
+  // Convert to delta-time + event bytes
+  const out: number[] = [];
+  let lastTick = 0;
+  for (const ev of absEvents) {
+    const delta = ev.tick - lastTick;
+    out.push(...vlq(delta));
+    out.push(...ev.bytes);
+    lastTick = ev.tick;
+  }
+  // End of track
+  out.push(0); // delta
+  out.push(0xff, 0x2f, 0x00);
+
+  return wrapTrack(new Uint8Array(out));
+}
+
+function wrapTrack(content: Uint8Array): Uint8Array {
+  const out = new Uint8Array(8 + content.length);
+  out.set([0x4d, 0x54, 0x72, 0x6b], 0); // "MTrk"
+  writeUint32(out, 4, content.length);
+  out.set(content, 8);
+  return out;
+}
+
+export function vlq(n: number): number[] {
+  if (n < 0) throw new RangeError("VLQ requires non-negative");
+  if (n === 0) return [0];
+  const bytes: number[] = [];
+  let v = n;
+  bytes.push(v & 0x7f);
+  v >>= 7;
+  while (v > 0) {
+    bytes.push((v & 0x7f) | 0x80);
+    v >>= 7;
+  }
+  return bytes.reverse();
+}
+
+function writeUint32(buf: Uint8Array, offset: number, value: number): void {
+  buf[offset] = (value >>> 24) & 0xff;
+  buf[offset + 1] = (value >>> 16) & 0xff;
+  buf[offset + 2] = (value >>> 8) & 0xff;
+  buf[offset + 3] = value & 0xff;
+}
+
+function writeUint16(buf: Uint8Array, offset: number, value: number): void {
+  buf[offset] = (value >>> 8) & 0xff;
+  buf[offset + 1] = value & 0xff;
+}
+
+function getMidiChannel(events: TimelineEvent[]): number | undefined {
+  for (const ev of events) {
+    const a = ev.annotations.find((x) => x.name === "@midi_channel");
+    if (a && typeof a.args[0] === "number") return Math.max(0, Math.min(15, a.args[0] - 1));
+  }
+  return undefined;
+}
+
+function getMidiProgram(events: TimelineEvent[]): number | undefined {
+  for (const ev of events) {
+    const a = ev.annotations.find((x) => x.name === "@midi_program");
+    if (a && typeof a.args[0] === "number") return Math.max(0, Math.min(127, a.args[0]));
+  }
+  return undefined;
+}
+
+function annotationOverrideChannel(annotations: AnnotationData[]): number | undefined {
+  const a = annotations.find((x) => x.name === "@midi_channel");
+  if (a && typeof a.args[0] === "number") return Math.max(0, Math.min(15, a.args[0] - 1));
+  return undefined;
+}

--- a/src/tools/format.test.ts
+++ b/src/tools/format.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import { format } from "./format.js";
+
+describe("format — basic", () => {
+  it("4 c4 -> '4 c4\\n'", () => {
+    expect(format("4 c4")).toBe("4 c4\n");
+  });
+  it("multiple events on one line", () => {
+    expect(format("4 c4 d4 e4 f4")).toBe("4 c4 d4 e4 f4\n");
+  });
+  it("preserves directives", () => {
+    expect(format("\\tempo 120\n4 c4")).toContain("\\tempo 120");
+  });
+});
+
+describe("format — version", () => {
+  it("\\version always first", () => {
+    const out = format('\\tempo 120\n\\version "2.0"\n4 c4');
+    expect(out.startsWith('\\version "2.0"')).toBe(true);
+  });
+});
+
+describe("format — voice", () => {
+  it("voice body indented 2 spaces", () => {
+    const out = format("voice melody { 4 c4 }");
+    expect(out).toContain("voice melody {");
+    expect(out).toContain("  4 c4");
+    expect(out).toContain("}");
+  });
+});
+
+describe("format — bindings", () => {
+  it("single-event binding inline", () => {
+    expect(format("intro = 4 c4")).toContain("intro = 4 c4");
+  });
+  it("multi-event binding uses block", () => {
+    const out = format("intro = { 4 c4 d4 }");
+    expect(out).toContain("intro = {");
+    expect(out).toContain("  4 c4 d4");
+  });
+  it("doc comment preserved", () => {
+    const out = format("/// my motif\nintro = 4 c4");
+    expect(out).toContain("/// my motif");
+  });
+  it("parameterized binding", () => {
+    expect(format("arp(root) = 8 root")).toContain("arp(root) = 8 root");
+  });
+});
+
+describe("format — chord", () => {
+  it("chord syntax", () => {
+    expect(format("4 <c4 e4 g4>")).toContain("<c4 e4 g4>");
+  });
+});
+
+describe("format — slide", () => {
+  it("slide arrow with spaces", () => {
+    expect(format("2 e2 -> c3")).toContain("2 e2 -> c3");
+  });
+});
+
+describe("format — articulation", () => {
+  it("staccato postfix", () => {
+    expect(format("4 c4.")).toContain("4 c4.");
+  });
+});
+
+describe("format — annotations", () => {
+  it("postfix on event no space", () => {
+    expect(format('4 c4@cue("hit")')).toContain('4 c4@cue("hit")');
+  });
+  it("prefix on block on own line", () => {
+    const out = format('@section("verse") { 4 c4 }');
+    expect(out).toContain('@section("verse")');
+    expect(out).toContain("{");
+  });
+});
+
+describe("format — effects/envelope/tuplet/ramp", () => {
+  it("with reverb", () => {
+    expect(format("with reverb(2, 1, 0.7) { 4 c4 }")).toContain("with reverb(2, 1, 0.7)");
+  });
+  it("envelope adsr", () => {
+    expect(format("envelope adsr(0.01, 0.1, 0.7, 0.3) { 4 c4 }")).toContain(
+      "envelope adsr(0.01, 0.1, 0.7, 0.3)",
+    );
+  });
+  it("tuplet", () => {
+    expect(format("tuplet(5) { 8 c4 d4 e4 f4 g4 }")).toContain("tuplet(5)");
+  });
+  it("ramp", () => {
+    expect(format("ramp(\\mp, \\ff) { 4 c4 d4 }")).toContain("ramp(\\mp, \\ff)");
+  });
+});
+
+describe("format — repeat", () => {
+  it("event * N", () => {
+    expect(format("4 c4 * 4")).toContain("4 c4 * 4");
+  });
+  it("repeat block", () => {
+    expect(format("repeat 3 { 4 c4 }")).toContain("repeat 3 {");
+  });
+});
+
+describe("format — instrument define", () => {
+  it("multi-line block", () => {
+    const out = format("instrument define warm { oscillator sawtooth detune 5 }");
+    expect(out).toContain("instrument define warm {");
+    expect(out).toContain("  oscillator sawtooth");
+    expect(out).toContain("  detune 5");
+  });
+});
+
+describe("format — pitch arithmetic", () => {
+  it("c4+7", () => {
+    expect(format("4 c4+7")).toContain("c4+7");
+  });
+});
+
+describe("format — scale degree", () => {
+  it("^N", () => {
+    expect(format("\\key c4 major\n4 ^1 ^3 ^5")).toContain("^1 ^3 ^5");
+  });
+});
+
+describe("format — idempotent", () => {
+  it("format(format(x)) === format(x)", () => {
+    const inputs = [
+      "4 c4",
+      '\\version "2.0"\n\\tempo 120\nvoice melody { 4 c4 d4 }',
+      "with reverb(2, 1, 0.7) { 4 <c4 e4 g4> }",
+      "ramp(\\p, \\ff) { 4 c4 d4 e4 f4 }",
+    ];
+    for (const src of inputs) {
+      const once = format(src);
+      const twice = format(once);
+      expect(twice).toBe(once);
+    }
+  });
+});
+
+describe("format — round trip semantic equivalence", () => {
+  it("format output parses to same AST shape", () => {
+    // Parse original and formatted; compare body length
+    const src = "\\tempo 120\nvoice melody { 4 c4 d4 e4 f4 }";
+    const formatted = format(src);
+    // The formatted output should re-parse without error
+    expect(() => format(formatted)).not.toThrow();
+  });
+});

--- a/src/tools/format.ts
+++ b/src/tools/format.ts
@@ -1,0 +1,685 @@
+import type {
+  AbsolutePitch,
+  AnnotatedBlock,
+  AnnotatedEvent,
+  Annotation,
+  Arg,
+  ArticulationMark,
+  BarMarker,
+  Binding,
+  Block,
+  Call,
+  CallExpr,
+  ChordEvent,
+  Composition,
+  DurationToken,
+  DynamicMarker,
+  EnvelopeExpr,
+  Event,
+  EventList,
+  InheritedPitchLetter,
+  InstrumentDef,
+  InstrumentField,
+  MotifRef,
+  NoteEvent,
+  ParamRef,
+  PitchArith,
+  PitchTerm,
+  RampExpr,
+  RepeatExpr,
+  RestEvent,
+  ScaleDegree,
+  SlideEvent,
+  SustainEvent,
+  TieEvent,
+  TopLevel,
+  TupletExpr,
+  UseDecl,
+  VoiceDecl,
+  WithExpr,
+} from "../ast/nodes.js";
+import { lex } from "../lexer/lexer.js";
+import { parse } from "../parser/parser.js";
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function format(source: string): string {
+  const ast = parse(lex(source));
+  return printComposition(ast);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function indent(n: number): string {
+  return "  ".repeat(n);
+}
+
+function formatNumber(n: number): string {
+  // Emit integer if no fractional part, otherwise trim trailing zeros
+  if (Number.isInteger(n)) return String(n);
+  const s = String(n);
+  return s.replace(/\.?0+$/, "") || "0";
+}
+
+/**
+ * Returns true for event node kinds that should be grouped with adjacent
+ * events onto a single output line.
+ */
+function isInlineEvent(n: TopLevel): boolean {
+  switch (n.kind) {
+    case "Note":
+    case "Chord":
+    case "Rest":
+    case "Sustain":
+    case "Tie":
+    case "Slide":
+    case "Dynamic":
+    case "MotifRef":
+    case "Call":
+    case "Annotated":
+      return true;
+    default:
+      return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Composition
+// ---------------------------------------------------------------------------
+
+function printComposition(c: Composition): string {
+  // Collect version — either from the parsed composition.version field,
+  // or from any Version directive in the body (hoist it to first position).
+  let version = c.version;
+  let body = c.body;
+
+  if (!version) {
+    const versionNode = body.find((n) => n.kind === "Version");
+    if (versionNode && versionNode.kind === "Version") {
+      version = versionNode.version;
+      body = body.filter((n) => n !== versionNode);
+    }
+  }
+
+  const lines: string[] = [];
+
+  if (version !== undefined) {
+    lines.push(`\\version "${version}"`);
+  }
+
+  // Emit body, grouping consecutive inline events onto a single line
+  for (const group of groupTopLevelNodes(body)) {
+    lines.push(printTopLevelGroup(group, 0));
+  }
+
+  const joined = lines.join("\n");
+  // Collapse 3+ consecutive newlines to 2 (one blank line max)
+  const normalized = joined.replace(/\n{3,}/g, "\n\n");
+  return `${normalized.trimEnd()}\n`;
+}
+
+/**
+ * Group top-level nodes: consecutive inline events are batched together.
+ * Non-inline nodes are each their own group (single-element array).
+ */
+function groupTopLevelNodes(nodes: TopLevel[]): TopLevel[][] {
+  const groups: TopLevel[][] = [];
+  let current: TopLevel[] = [];
+
+  for (const n of nodes) {
+    if (isInlineEvent(n)) {
+      current.push(n);
+    } else {
+      if (current.length > 0) {
+        groups.push(current);
+        current = [];
+      }
+      groups.push([n]);
+    }
+  }
+
+  if (current.length > 0) {
+    groups.push(current);
+  }
+
+  return groups;
+}
+
+function printTopLevelGroup(group: TopLevel[], depth: number): string {
+  const first = group[0];
+  if (group.length === 1 && first !== undefined && !isInlineEvent(first)) {
+    return printTopLevel(first, depth);
+  }
+  // All inline events — print on one line
+  return `${indent(depth)}${group.map((n) => printEventInline(n as Event)).join(" ")}`;
+}
+
+// ---------------------------------------------------------------------------
+// Top-level (non-inline structural nodes)
+// ---------------------------------------------------------------------------
+
+function printTopLevel(n: TopLevel, depth: number): string {
+  switch (n.kind) {
+    case "UseDecl":
+      return printUseDecl(n);
+    case "Tempo":
+      return `${indent(depth)}\\tempo ${formatNumber(n.value)}`;
+    case "Time":
+      return `${indent(depth)}\\time ${n.numerator}/${n.denominator}`;
+    case "Key":
+      return `${indent(depth)}\\key ${printAbsolutePitch(n.tonic)} ${n.mode}`;
+    case "Instrument":
+      return `${indent(depth)}\\instrument ${n.name}`;
+    case "Detune":
+      return `${indent(depth)}\\detune ${formatNumber(n.cents)}`;
+    case "Version":
+      return `${indent(depth)}\\version "${n.version}"`;
+    case "Binding":
+      return printBinding(n, depth);
+    case "VoiceDecl":
+      return printVoiceDecl(n, depth);
+    case "InstrumentDef":
+      return printInstrumentDef(n, depth);
+    // Block-level events (repeat, with, ramp, etc.) fall through to event printer
+    default:
+      return printEvent(n as Event, depth);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Use declaration
+// ---------------------------------------------------------------------------
+
+function printUseDecl(n: UseDecl): string {
+  if (n.alias) return `\\use "${n.path}" as ${n.alias}`;
+  if (n.selected && n.selected.length > 0) return `\\use "${n.path}" (${n.selected.join(", ")})`;
+  return `\\use "${n.path}"`;
+}
+
+// ---------------------------------------------------------------------------
+// Binding
+// ---------------------------------------------------------------------------
+
+function printBinding(n: Binding, depth: number): string {
+  const lines: string[] = [];
+
+  if (n.doc) {
+    for (const line of n.doc.split("\n")) {
+      lines.push(`${indent(depth)}/// ${line.trim()}`);
+    }
+  }
+
+  const sig = n.params ? `${n.name}(${n.params.join(", ")})` : n.name;
+  const lhs = `${indent(depth)}${sig} = `;
+
+  if (n.body.kind === "EventList") {
+    lines.push(`${lhs}${printEventList(n.body, depth)}`);
+  } else {
+    // Block body
+    lines.push(`${lhs}${printBlockInline(n.body, depth)}`);
+  }
+
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Voice declaration
+// ---------------------------------------------------------------------------
+
+function printVoiceDecl(n: VoiceDecl, depth: number): string {
+  const lines: string[] = [];
+
+  if (n.doc) {
+    for (const line of n.doc.split("\n")) {
+      lines.push(`${indent(depth)}/// ${line.trim()}`);
+    }
+  }
+
+  for (const ann of n.annotations) {
+    lines.push(`${indent(depth)}${printAnnotation(ann)}`);
+  }
+
+  lines.push(`${indent(depth)}voice ${n.name} {`);
+  for (const group of groupTopLevelNodes(n.body.body)) {
+    lines.push(printTopLevelGroup(group, depth + 1));
+  }
+  lines.push(`${indent(depth)}}`);
+
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Instrument definition
+// ---------------------------------------------------------------------------
+
+function printInstrumentDef(n: InstrumentDef, depth: number): string {
+  const lines: string[] = [];
+
+  if (n.doc) {
+    for (const line of n.doc.split("\n")) {
+      lines.push(`${indent(depth)}/// ${line.trim()}`);
+    }
+  }
+
+  lines.push(`${indent(depth)}instrument define ${n.name} {`);
+  for (const field of n.fields) {
+    lines.push(printInstrumentField(field, depth + 1));
+  }
+  lines.push(`${indent(depth)}}`);
+
+  return lines.join("\n");
+}
+
+function printInstrumentField(f: InstrumentField, depth: number): string {
+  switch (f.kind) {
+    case "Oscillator":
+      return `${indent(depth)}oscillator ${f.value}`;
+    case "EnvelopeField":
+      return `${indent(depth)}envelope ${printCall(f.call)}`;
+    case "FilterField":
+      return `${indent(depth)}filter ${printCall(f.call)}`;
+    case "DetuneField":
+      return `${indent(depth)}detune ${formatNumber(f.cents)}`;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Block helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Print a block body with grouped lines, used for voice/repeat/with/etc.
+ * Opening brace on same line as header.
+ */
+function printBlockBody(b: Block, depth: number): string {
+  if (b.body.length === 0) return "{}";
+  const lines: string[] = ["{"];
+  for (const group of groupTopLevelNodes(b.body)) {
+    lines.push(printTopLevelGroup(group, depth + 1));
+  }
+  lines.push(`${indent(depth)}}`);
+  return lines.join("\n");
+}
+
+/**
+ * Print a block used as binding RHS.
+ * Returns the block starting with `{` (caller provides leading `name = `).
+ */
+function printBlockInline(b: Block, depth: number): string {
+  if (b.body.length === 0) return "{}";
+  const lines: string[] = ["{"];
+  for (const group of groupTopLevelNodes(b.body)) {
+    lines.push(printTopLevelGroup(group, depth + 1));
+  }
+  lines.push(`${indent(depth)}}`);
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// EventList
+// ---------------------------------------------------------------------------
+
+/**
+ * Print all events in an EventList on a single line.
+ */
+function printEventList(el: EventList, _depth: number): string {
+  return el.events.map((e) => printEventInline(e)).join(" ");
+}
+
+// ---------------------------------------------------------------------------
+// Events
+// ---------------------------------------------------------------------------
+
+function printEvent(e: Event, depth: number): string {
+  switch (e.kind) {
+    case "Bar":
+      return printBarMarker(e, depth);
+    case "Dynamic":
+      return `${indent(depth)}${printDynamic(e)}`;
+    case "Note":
+      return `${indent(depth)}${printNoteInline(e)}`;
+    case "Chord":
+      return `${indent(depth)}${printChordInline(e)}`;
+    case "Slide":
+      return `${indent(depth)}${printSlideInline(e)}`;
+    case "Rest":
+      return `${indent(depth)}${printRestInline(e)}`;
+    case "Sustain":
+      return `${indent(depth)}~ ${printPitchTerm(e.pitch)}`;
+    case "Tie":
+      return printTieInline(e, depth);
+    case "Ramp":
+      return printRamp(e, depth);
+    case "Repeat":
+      return printRepeat(e, depth);
+    case "With":
+      return printWith(e, depth);
+    case "Envelope":
+      return printEnvelope(e, depth);
+    case "Tuplet":
+      return printTuplet(e, depth);
+    case "MotifRef":
+      return `${indent(depth)}${e.name}`;
+    case "Call":
+      return `${indent(depth)}${printCallExpr(e)}`;
+    case "Annotated":
+      return printAnnotatedEvent(e, depth);
+    case "AnnotatedBlock":
+      return printAnnotatedBlock(e, depth);
+  }
+}
+
+/**
+ * Print an event as an inline fragment (no leading indent, no leading newlines).
+ */
+function printEventInline(e: Event): string {
+  switch (e.kind) {
+    case "Bar":
+      return e.double ? "||" : "|";
+    case "Dynamic":
+      return printDynamic(e);
+    case "Note":
+      return printNoteInline(e);
+    case "Chord":
+      return printChordInline(e);
+    case "Slide":
+      return printSlideInline(e);
+    case "Rest":
+      return printRestInline(e);
+    case "Sustain":
+      return `~ ${printPitchTerm(e.pitch)}`;
+    case "Tie":
+      return `${printNoteInline(e.left)} ~ ${printNoteInline(e.right)}`;
+    case "Ramp":
+      return `ramp(${e.from}, ${e.to}) ${printBlockBody(e.body, 0)}`;
+    case "Repeat":
+      return `repeat ${e.count} ${printBlockBody(e.body, 0)}`;
+    case "With":
+      return `with ${e.effects.map(printCall).join(", ")} ${printBlockBody(e.body, 0)}`;
+    case "Envelope":
+      return `envelope ${printCall(e.call)} ${printBlockBody(e.body, 0)}`;
+    case "Tuplet":
+      return printTupletInline(e);
+    case "MotifRef":
+      return e.name;
+    case "Call":
+      return printCallExpr(e);
+    case "Annotated":
+      return printAnnotatedEventInline(e);
+    case "AnnotatedBlock":
+      return printAnnotatedBlockInline(e);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Individual event printers (inline)
+// ---------------------------------------------------------------------------
+
+function printDynamic(e: DynamicMarker): string {
+  return e.value;
+}
+
+function printNoteInline(e: NoteEvent): string {
+  let s = "";
+  if (e.duration) s += `${printDuration(e.duration)} `;
+  s += printPitchTerm(e.pitch);
+  s += printModifiers(e.modifiers);
+  for (const ann of e.annotations) {
+    s += printAnnotation(ann);
+  }
+  if (e.repeat !== undefined) s += ` * ${e.repeat}`;
+  return s;
+}
+
+function printChordInline(e: ChordEvent): string {
+  let s = "";
+  if (e.duration) s += `${printDuration(e.duration)} `;
+  s += `<${e.pitches.map(printPitchTerm).join(" ")}>`;
+  s += printModifiers(e.modifiers);
+  for (const ann of e.annotations) {
+    s += printAnnotation(ann);
+  }
+  if (e.repeat !== undefined) s += ` * ${e.repeat}`;
+  return s;
+}
+
+function printSlideInline(e: SlideEvent): string {
+  const src = printNoteInline(e.source);
+  const dst = printNoteInline(e.destination);
+  return `${src} -> ${dst}`;
+}
+
+function printRestInline(e: RestEvent): string {
+  let s = "";
+  if (e.duration) s += `${printDuration(e.duration)} `;
+  s += "r";
+  s += printModifiers(e.modifiers);
+  for (const ann of e.annotations) {
+    s += printAnnotation(ann);
+  }
+  return s;
+}
+
+function printTieInline(e: TieEvent, depth: number): string {
+  return `${indent(depth)}${printNoteInline(e.left)} ~ ${printNoteInline(e.right)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Block events (need indentation)
+// ---------------------------------------------------------------------------
+
+function printBarMarker(e: BarMarker, depth: number): string {
+  return `${indent(depth)}${e.double ? "||" : "|"}`;
+}
+
+function printRamp(e: RampExpr, depth: number): string {
+  if (e.body.body.length === 0) return `${indent(depth)}ramp(${e.from}, ${e.to}) {}`;
+  const header = `${indent(depth)}ramp(${e.from}, ${e.to}) {`;
+  const body = groupTopLevelNodes(e.body.body)
+    .map((g) => printTopLevelGroup(g, depth + 1))
+    .join("\n");
+  const close = `${indent(depth)}}`;
+  return [header, body, close].join("\n");
+}
+
+function printRepeat(e: RepeatExpr, depth: number): string {
+  if (e.body.body.length === 0) return `${indent(depth)}repeat ${e.count} {}`;
+  const header = `${indent(depth)}repeat ${e.count} {`;
+  const body = groupTopLevelNodes(e.body.body)
+    .map((g) => printTopLevelGroup(g, depth + 1))
+    .join("\n");
+  const close = `${indent(depth)}}`;
+  return [header, body, close].join("\n");
+}
+
+function printWith(e: WithExpr, depth: number): string {
+  const effectStr = e.effects.map(printCall).join(", ");
+  if (e.body.body.length === 0) return `${indent(depth)}with ${effectStr} {}`;
+  const header = `${indent(depth)}with ${effectStr} {`;
+  const body = groupTopLevelNodes(e.body.body)
+    .map((g) => printTopLevelGroup(g, depth + 1))
+    .join("\n");
+  const close = `${indent(depth)}}`;
+  return [header, body, close].join("\n");
+}
+
+function printEnvelope(e: EnvelopeExpr, depth: number): string {
+  const callStr = printCall(e.call);
+  if (e.body.body.length === 0) return `${indent(depth)}envelope ${callStr} {}`;
+  const header = `${indent(depth)}envelope ${callStr} {`;
+  const body = groupTopLevelNodes(e.body.body)
+    .map((g) => printTopLevelGroup(g, depth + 1))
+    .join("\n");
+  const close = `${indent(depth)}}`;
+  return [header, body, close].join("\n");
+}
+
+function printTuplet(e: TupletExpr, depth: number): string {
+  const spec = e.m !== undefined ? `${e.n}, ${e.m}` : String(e.n);
+  if (e.body.body.length === 0) return `${indent(depth)}tuplet(${spec}) {}`;
+  const header = `${indent(depth)}tuplet(${spec}) {`;
+  const body = groupTopLevelNodes(e.body.body)
+    .map((g) => printTopLevelGroup(g, depth + 1))
+    .join("\n");
+  const close = `${indent(depth)}}`;
+  return [header, body, close].join("\n");
+}
+
+function printTupletInline(e: TupletExpr): string {
+  const spec = e.m !== undefined ? `${e.n}, ${e.m}` : String(e.n);
+  return `tuplet(${spec}) ${printBlockBody(e.body, 0)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Annotated events/blocks
+// ---------------------------------------------------------------------------
+
+function printAnnotatedEvent(e: AnnotatedEvent, depth: number): string {
+  // Annotations are postfix on the event with no separator
+  const inner = printEventInline(e.target);
+  const anns = e.annotations.map(printAnnotation).join("");
+  return `${indent(depth)}${inner}${anns}`;
+}
+
+function printAnnotatedEventInline(e: AnnotatedEvent): string {
+  const inner = printEventInline(e.target);
+  const anns = e.annotations.map(printAnnotation).join("");
+  return `${inner}${anns}`;
+}
+
+function printAnnotatedBlock(e: AnnotatedBlock, depth: number): string {
+  const lines: string[] = [];
+  for (const ann of e.annotations) {
+    lines.push(`${indent(depth)}${printAnnotation(ann)}`);
+  }
+  // Print the block body indented under the annotations
+  if (e.target.body.length === 0) {
+    lines.push(`${indent(depth)}{}`);
+  } else {
+    lines.push(`${indent(depth)}{`);
+    for (const group of groupTopLevelNodes(e.target.body)) {
+      lines.push(printTopLevelGroup(group, depth + 1));
+    }
+    lines.push(`${indent(depth)}}`);
+  }
+  return lines.join("\n");
+}
+
+function printAnnotatedBlockInline(e: AnnotatedBlock): string {
+  const anns = e.annotations.map(printAnnotation).join("\n");
+  const block = printBlockBody(e.target, 0);
+  return `${anns}\n${block}`;
+}
+
+// ---------------------------------------------------------------------------
+// Pitch terms
+// ---------------------------------------------------------------------------
+
+function printPitchTerm(p: PitchTerm): string {
+  switch (p.kind) {
+    case "Pitch":
+      return printAbsolutePitch(p);
+    case "ScaleDegree":
+      return printScaleDegree(p);
+    case "PitchArith":
+      return printPitchArith(p);
+    case "ParamRef":
+      return printParamRef(p);
+    case "InheritedPitchLetter":
+      return printInheritedPitchLetter(p);
+  }
+}
+
+function printAbsolutePitch(p: AbsolutePitch): string {
+  let s = p.letter;
+  if (p.accidental !== null) s += p.accidental;
+  s += String(p.octave);
+  if (p.cents !== 0) {
+    s += p.cents > 0 ? `+${p.cents}c` : `${p.cents}c`;
+  }
+  return s;
+}
+
+function printScaleDegree(p: ScaleDegree): string {
+  const sign = p.degree < 0 ? "-" : "";
+  let s = `^${sign}${Math.abs(p.degree)}`;
+  if (p.accidental) s += p.accidental;
+  return s;
+}
+
+function printPitchArith(p: PitchArith): string {
+  const base = printPitchTerm(p.base);
+  if (p.semitones >= 0) return `${base}+${p.semitones}`;
+  return `${base}${p.semitones}`;
+}
+
+function printParamRef(p: ParamRef): string {
+  return p.name;
+}
+
+function printInheritedPitchLetter(p: InheritedPitchLetter): string {
+  let s = p.letter;
+  if (p.accidental) s += p.accidental;
+  return s;
+}
+
+// ---------------------------------------------------------------------------
+// Duration
+// ---------------------------------------------------------------------------
+
+function printDuration(d: DurationToken): string {
+  return d.raw;
+}
+
+// ---------------------------------------------------------------------------
+// Modifiers (articulation)
+// ---------------------------------------------------------------------------
+
+function printModifiers(marks: ArticulationMark[]): string {
+  return marks.map((m) => m.mark).join("");
+}
+
+// ---------------------------------------------------------------------------
+// Annotations
+// ---------------------------------------------------------------------------
+
+function printAnnotation(a: Annotation): string {
+  // Annotation name already includes the '@' prefix from the lexer
+  if (a.args.length === 0) return a.name;
+  return `${a.name}(${a.args.map(printArg).join(", ")})`;
+}
+
+// ---------------------------------------------------------------------------
+// Call
+// ---------------------------------------------------------------------------
+
+function printCall(c: Call): string {
+  return `${c.name}(${c.args.map(printArg).join(", ")})`;
+}
+
+function printCallExpr(c: CallExpr): string {
+  return `${c.name}(${c.args.map(printArg).join(", ")})`;
+}
+
+// ---------------------------------------------------------------------------
+// Args
+// ---------------------------------------------------------------------------
+
+function printArg(a: Arg): string {
+  switch (a.kind) {
+    case "NumberArg":
+      return formatNumber(a.value);
+    case "StringArg":
+      return `"${a.value}"`;
+    case "PitchArg":
+      return printPitchTerm(a.value);
+    case "IdentArg":
+      return a.name;
+    case "NamedArg":
+      return `${a.name}: ${printArg(a.value)}`;
+  }
+}

--- a/src/tools/gen-docs.test.ts
+++ b/src/tools/gen-docs.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { generateDocs } from "./gen-docs.js";
+
+describe("generateDocs — binding with doc", () => {
+  it("emits markdown heading and doc body for a binding with doc comment", () => {
+    const source = "/// A simple intro phrase.\nintro = 4 c4 d e f";
+    const result = generateDocs(source);
+    expect(result).toContain("## `intro`");
+    expect(result).toContain("A simple intro phrase.");
+  });
+});
+
+describe("generateDocs — parameterized binding", () => {
+  it("shows parameters in the heading: ## `arp(root)`", () => {
+    const source = "/// An arpeggio motif.\narp(root) = 8 <root root root>";
+    const result = generateDocs(source);
+    expect(result).toContain("## `arp(root)`");
+  });
+});
+
+describe("generateDocs — instrument definition", () => {
+  it("lists instrument as '## instrument `warm_pad`'", () => {
+    const source = "/// A warm pad sound.\ninstrument define warm_pad { oscillator sawtooth }";
+    const result = generateDocs(source);
+    expect(result).toContain("## instrument `warm_pad`");
+    expect(result).toContain("A warm pad sound.");
+  });
+});
+
+describe("generateDocs — voice declaration", () => {
+  it("lists voice as '## voice `melody`'", () => {
+    const source = "/// The main melody.\nvoice melody { 4 c4 d e f }";
+    const result = generateDocs(source);
+    expect(result).toContain("## voice `melody`");
+    expect(result).toContain("The main melody.");
+  });
+});
+
+describe("generateDocs — declaration order", () => {
+  it("multiple bindings appear in declaration order", () => {
+    const source = [
+      "/// First motif.",
+      "alpha = 4 c4",
+      "/// Second motif.",
+      "beta = 4 d4",
+      "/// Third motif.",
+      "gamma = 4 e4",
+    ].join("\n");
+    const result = generateDocs(source);
+    const alphaPos = result.indexOf("## `alpha`");
+    const betaPos = result.indexOf("## `beta`");
+    const gammaPos = result.indexOf("## `gamma`");
+    expect(alphaPos).toBeLessThan(betaPos);
+    expect(betaPos).toBeLessThan(gammaPos);
+  });
+});
+
+describe("generateDocs — title option", () => {
+  it("output starts with the given title as an H1 heading", () => {
+    const source = "intro = 4 c4";
+    const result = generateDocs(source, { title: "My Composition" });
+    expect(result.startsWith("# My Composition")).toBe(true);
+    expect(result).toContain("## `intro`");
+  });
+});
+
+describe("generateDocs — empty source", () => {
+  it("returns empty string when there are no documented nodes", () => {
+    const result = generateDocs("");
+    expect(result).toBe("");
+  });
+
+  it("returns only the title when title given but no documented nodes", () => {
+    const result = generateDocs("", { title: "Empty" });
+    expect(result.trim()).toBe("# Empty");
+  });
+});

--- a/src/tools/gen-docs.ts
+++ b/src/tools/gen-docs.ts
@@ -1,0 +1,42 @@
+import type { Binding, InstrumentDef, VoiceDecl } from "../ast/nodes.js";
+import { lex } from "../lexer/lexer.js";
+import { parse } from "../parser/parser.js";
+
+export type GenDocsOptions = {
+  title?: string;
+};
+
+export function generateDocs(source: string, opts: GenDocsOptions = {}): string {
+  const ast = parse(lex(source));
+  const lines: string[] = [];
+  if (opts.title) {
+    lines.push(`# ${opts.title}`);
+    lines.push("");
+  }
+  for (const node of ast.body) {
+    if (node.kind === "Binding") {
+      const sig = node.params ? `${node.name}(${node.params.join(", ")})` : node.name;
+      lines.push(`## \`${sig}\``);
+      lines.push("");
+      if (node.doc) {
+        lines.push(node.doc.trim());
+        lines.push("");
+      }
+    } else if (node.kind === "InstrumentDef") {
+      lines.push(`## instrument \`${node.name}\``);
+      lines.push("");
+      if (node.doc) {
+        lines.push(node.doc.trim());
+        lines.push("");
+      }
+    } else if (node.kind === "VoiceDecl") {
+      lines.push(`## voice \`${node.name}\``);
+      lines.push("");
+      if (node.doc) {
+        lines.push(node.doc.trim());
+        lines.push("");
+      }
+    }
+  }
+  return lines.join("\n");
+}

--- a/src/tools/render-wav.test.ts
+++ b/src/tools/render-wav.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { audioBufferToWav, renderToWav } from "./render-wav.js";
+import { MockAudioContext } from "../runtime/mock-audio-context.js";
+import type { AudioBufferLike } from "../runtime/audio-context.js";
+
+class MockOfflineAudioContext extends MockAudioContext {
+  private renderResult: AudioBufferLike;
+  constructor(channels: number, length: number, sampleRate: number) {
+    super();
+    this.sampleRate = sampleRate;
+    this.renderResult = this.createBuffer(channels, length, sampleRate);
+  }
+  async startRendering(): Promise<AudioBufferLike> {
+    return this.renderResult;
+  }
+  setBuffer(buf: AudioBufferLike): void {
+    this.renderResult = buf;
+  }
+}
+
+describe("audioBufferToWav — header", () => {
+  it("RIFF/WAVE/fmt/data chunks", () => {
+    const ctx = new MockOfflineAudioContext(2, 100, 44100);
+    const buf = ctx.createBuffer(2, 100, 44100);
+    const wav = audioBufferToWav(buf);
+    expect(String.fromCharCode(wav[0]!, wav[1]!, wav[2]!, wav[3]!)).toBe("RIFF");
+    expect(String.fromCharCode(wav[8]!, wav[9]!, wav[10]!, wav[11]!)).toBe("WAVE");
+    expect(String.fromCharCode(wav[12]!, wav[13]!, wav[14]!, wav[15]!)).toBe("fmt ");
+    expect(String.fromCharCode(wav[36]!, wav[37]!, wav[38]!, wav[39]!)).toBe("data");
+  });
+
+  it("PCM format code", () => {
+    const ctx = new MockOfflineAudioContext(1, 100, 44100);
+    const buf = ctx.createBuffer(1, 100, 44100);
+    const wav = audioBufferToWav(buf);
+    // Bytes 20-21: format code (LE), should be 1
+    expect(wav[20]).toBe(1);
+    expect(wav[21]).toBe(0);
+  });
+
+  it("sample rate encoded little-endian", () => {
+    const ctx = new MockOfflineAudioContext(1, 100, 44100);
+    const buf = ctx.createBuffer(1, 100, 44100);
+    const wav = audioBufferToWav(buf);
+    // Bytes 24-27: sample rate (LE), 44100 = 0x0000AC44
+    expect(wav[24]).toBe(0x44);
+    expect(wav[25]).toBe(0xac);
+    expect(wav[26]).toBe(0x00);
+    expect(wav[27]).toBe(0x00);
+  });
+
+  it("data size matches samples * channels * 2 bytes", () => {
+    const ctx = new MockOfflineAudioContext(2, 1000, 44100);
+    const buf = ctx.createBuffer(2, 1000, 44100);
+    const wav = audioBufferToWav(buf);
+    // Bytes 40-43: data size (LE), should be 2 * 1000 * 2 = 4000
+    const dataSize = wav[40]! | (wav[41]! << 8) | (wav[42]! << 16) | (wav[43]! << 24);
+    expect(dataSize).toBe(4000);
+  });
+
+  it("total file size = 8 + 36 + dataSize", () => {
+    const ctx = new MockOfflineAudioContext(1, 100, 44100);
+    const buf = ctx.createBuffer(1, 100, 44100);
+    const wav = audioBufferToWav(buf);
+    const dataSize = 100 * 1 * 2;
+    expect(wav.length).toBe(8 + 36 + dataSize);
+  });
+
+  it("sample data interleaved across channels", () => {
+    const ctx = new MockOfflineAudioContext(2, 4, 44100);
+    const buf = ctx.createBuffer(2, 4, 44100);
+    // Set channel 0 to 0.5, channel 1 to -0.5
+    const ch0 = buf.getChannelData(0);
+    const ch1 = buf.getChannelData(1);
+    for (let i = 0; i < 4; i++) {
+      ch0[i] = 0.5;
+      ch1[i] = -0.5;
+    }
+    const wav = audioBufferToWav(buf);
+    // Data starts at offset 44; first sample channel 0 = 0.5 * 0x7FFF = 16383 = 0x3FFF (LE: 0xFF 0x3F)
+    expect(wav[44]).toBe(0xff);
+    expect(wav[45]).toBe(0x3f);
+    // Second sample channel 1 = -0.5 * 0x8000 = -16384 = 0xC000 (two's complement, LE: 0x00 0xC0)
+    expect(wav[46]).toBe(0x00);
+    expect(wav[47]).toBe(0xc0);
+  });
+
+  it("clips out-of-range samples", () => {
+    const ctx = new MockOfflineAudioContext(1, 1, 44100);
+    const buf = ctx.createBuffer(1, 1, 44100);
+    buf.getChannelData(0)[0] = 2.0; // exceeds 1.0
+    const wav = audioBufferToWav(buf);
+    // Clipped to 1.0 = 0x7FFF (LE: 0xFF 0x7F)
+    expect(wav[44]).toBe(0xff);
+    expect(wav[45]).toBe(0x7f);
+  });
+});
+
+describe("renderToWav", () => {
+  it("renders a CompositionIR via OfflineAudioContext", async () => {
+    const ctx = new MockOfflineAudioContext(2, 1000, 44100);
+    const ir = {
+      tempo: 60,
+      timeSig: { numerator: 4, denominator: 4 },
+      voices: [],
+      diagnostics: [],
+    };
+    const wav = await renderToWav(ir, ctx);
+    expect(wav.length).toBeGreaterThan(44); // at least header
+    expect(String.fromCharCode(wav[0]!, wav[1]!, wav[2]!, wav[3]!)).toBe("RIFF");
+  });
+});

--- a/src/tools/render-wav.test.ts
+++ b/src/tools/render-wav.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { audioBufferToWav, renderToWav } from "./render-wav.js";
-import { MockAudioContext } from "../runtime/mock-audio-context.js";
 import type { AudioBufferLike } from "../runtime/audio-context.js";
+import { MockAudioContext } from "../runtime/mock-audio-context.js";
+import { audioBufferToWav, renderToWav } from "./render-wav.js";
 
 class MockOfflineAudioContext extends MockAudioContext {
   private renderResult: AudioBufferLike;
@@ -23,10 +23,11 @@ describe("audioBufferToWav — header", () => {
     const ctx = new MockOfflineAudioContext(2, 100, 44100);
     const buf = ctx.createBuffer(2, 100, 44100);
     const wav = audioBufferToWav(buf);
-    expect(String.fromCharCode(wav[0]!, wav[1]!, wav[2]!, wav[3]!)).toBe("RIFF");
-    expect(String.fromCharCode(wav[8]!, wav[9]!, wav[10]!, wav[11]!)).toBe("WAVE");
-    expect(String.fromCharCode(wav[12]!, wav[13]!, wav[14]!, wav[15]!)).toBe("fmt ");
-    expect(String.fromCharCode(wav[36]!, wav[37]!, wav[38]!, wav[39]!)).toBe("data");
+    const dec = new TextDecoder();
+    expect(dec.decode(wav.subarray(0, 4))).toBe("RIFF");
+    expect(dec.decode(wav.subarray(8, 12))).toBe("WAVE");
+    expect(dec.decode(wav.subarray(12, 16))).toBe("fmt ");
+    expect(dec.decode(wav.subarray(36, 40))).toBe("data");
   });
 
   it("PCM format code", () => {
@@ -54,7 +55,8 @@ describe("audioBufferToWav — header", () => {
     const buf = ctx.createBuffer(2, 1000, 44100);
     const wav = audioBufferToWav(buf);
     // Bytes 40-43: data size (LE), should be 2 * 1000 * 2 = 4000
-    const dataSize = wav[40]! | (wav[41]! << 8) | (wav[42]! << 16) | (wav[43]! << 24);
+    const dataSize =
+      (wav[40] ?? 0) | ((wav[41] ?? 0) << 8) | ((wav[42] ?? 0) << 16) | ((wav[43] ?? 0) << 24);
     expect(dataSize).toBe(4000);
   });
 
@@ -107,6 +109,6 @@ describe("renderToWav", () => {
     };
     const wav = await renderToWav(ir, ctx);
     expect(wav.length).toBeGreaterThan(44); // at least header
-    expect(String.fromCharCode(wav[0]!, wav[1]!, wav[2]!, wav[3]!)).toBe("RIFF");
+    expect(new TextDecoder().decode(wav.subarray(0, 4))).toBe("RIFF");
   });
 });

--- a/src/tools/render-wav.ts
+++ b/src/tools/render-wav.ts
@@ -1,0 +1,112 @@
+import type { CompositionIR } from "../ir/nodes.js";
+import { Composition } from "../runtime/composition.js";
+import type { AudioContextLike, AudioBufferLike } from "../runtime/audio-context.js";
+
+export interface OfflineAudioContextLike extends AudioContextLike {
+  startRendering(): Promise<AudioBufferLike>;
+}
+
+export type RenderOptions = {
+  durationSec?: number; // default = composition duration
+};
+
+export async function renderToWav(
+  ir: CompositionIR,
+  ctx: OfflineAudioContextLike,
+  opts: RenderOptions = {},
+): Promise<Uint8Array> {
+  void opts; // durationSec reserved for future use
+  const composition = new Composition(ir, { audioContext: ctx });
+  await composition.play();
+  const buffer = await ctx.startRendering();
+  return audioBufferToWav(buffer);
+}
+
+export function audioBufferToWav(buffer: AudioBufferLike): Uint8Array {
+  const channels = buffer.numberOfChannels;
+  const sampleRate = buffer.sampleRate;
+  const length = buffer.length;
+  const bytesPerSample = 2; // 16-bit PCM
+  const blockAlign = channels * bytesPerSample;
+  const byteRate = sampleRate * blockAlign;
+  const dataSize = length * blockAlign;
+  const fileSize = 36 + dataSize;
+
+  const buf = new Uint8Array(8 + fileSize);
+  let o = 0;
+
+  // "RIFF"
+  buf[o++] = 0x52;
+  buf[o++] = 0x49;
+  buf[o++] = 0x46;
+  buf[o++] = 0x46;
+  // file size - 8
+  writeUint32Le(buf, o, fileSize);
+  o += 4;
+  // "WAVE"
+  buf[o++] = 0x57;
+  buf[o++] = 0x41;
+  buf[o++] = 0x56;
+  buf[o++] = 0x45;
+  // "fmt "
+  buf[o++] = 0x66;
+  buf[o++] = 0x6d;
+  buf[o++] = 0x74;
+  buf[o++] = 0x20;
+  // fmt chunk size = 16
+  writeUint32Le(buf, o, 16);
+  o += 4;
+  // PCM = 1
+  writeUint16Le(buf, o, 1);
+  o += 2;
+  writeUint16Le(buf, o, channels);
+  o += 2;
+  writeUint32Le(buf, o, sampleRate);
+  o += 4;
+  writeUint32Le(buf, o, byteRate);
+  o += 4;
+  writeUint16Le(buf, o, blockAlign);
+  o += 2;
+  writeUint16Le(buf, o, 16); // bits per sample
+  o += 2;
+  // "data"
+  buf[o++] = 0x64;
+  buf[o++] = 0x61;
+  buf[o++] = 0x74;
+  buf[o++] = 0x61;
+  writeUint32Le(buf, o, dataSize);
+  o += 4;
+
+  // Interleaved samples
+  const channelData: Float32Array[] = [];
+  for (let c = 0; c < channels; c++) channelData.push(buffer.getChannelData(c));
+
+  for (let i = 0; i < length; i++) {
+    for (let c = 0; c < channels; c++) {
+      const sample = Math.max(-1, Math.min(1, channelData[c]?.[i] ?? 0));
+      const int16 = sample < 0 ? sample * 0x8000 : sample * 0x7fff;
+      writeInt16Le(buf, o, int16 | 0);
+      o += 2;
+    }
+  }
+
+  return buf;
+}
+
+function writeUint16Le(buf: Uint8Array, offset: number, value: number): void {
+  buf[offset] = value & 0xff;
+  buf[offset + 1] = (value >> 8) & 0xff;
+}
+
+function writeUint32Le(buf: Uint8Array, offset: number, value: number): void {
+  buf[offset] = value & 0xff;
+  buf[offset + 1] = (value >> 8) & 0xff;
+  buf[offset + 2] = (value >> 16) & 0xff;
+  buf[offset + 3] = (value >> 24) & 0xff;
+}
+
+function writeInt16Le(buf: Uint8Array, offset: number, value: number): void {
+  // Two's complement
+  const v = value < 0 ? value + 0x10000 : value;
+  writeUint16Le(buf, offset, v & 0xffff);
+}

--- a/src/tools/render-wav.ts
+++ b/src/tools/render-wav.ts
@@ -1,6 +1,6 @@
 import type { CompositionIR } from "../ir/nodes.js";
+import type { AudioBufferLike, AudioContextLike } from "../runtime/audio-context.js";
 import { Composition } from "../runtime/composition.js";
-import type { AudioContextLike, AudioBufferLike } from "../runtime/audio-context.js";
 
 export interface OfflineAudioContextLike extends AudioContextLike {
   startRendering(): Promise<AudioBufferLike>;

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,10 +1,19 @@
 import { defineConfig } from "tsup";
 
-export default defineConfig({
-  entry: ["src/index.ts"],
-  format: ["esm", "cjs"],
-  dts: true,
-  clean: true,
-  sourcemap: true,
-  target: "es2022",
-});
+export default defineConfig([
+  {
+    entry: ["src/index.ts"],
+    format: ["esm", "cjs"],
+    dts: true,
+    clean: true,
+    sourcemap: true,
+    target: "es2022",
+  },
+  {
+    entry: { cli: "src/cli/main.ts" },
+    format: ["esm"],
+    target: "es2022",
+    sourcemap: true,
+    banner: { js: "#!/usr/bin/env node" },
+  },
+]);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
       provider: "v8",
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
-      exclude: ["src/**/*.test.ts", "src/index.ts", "src/ast/nodes.ts", "src/ir/nodes.ts"],
+      exclude: ["src/**/*.test.ts", "src/index.ts", "src/ast/nodes.ts", "src/ir/nodes.ts", "src/cli/main.ts"],
       thresholds: {
         lines: 90,
         functions: 90,


### PR DESCRIPTION
## Summary

Phase 5 ships the tooling layer: formatter, MIDI export, JSON IR export, WAV offline render, doc generator, hot reload on `Composition`, and a `synth` CLI binary with six subcommands.

LSP is intentionally deferred to Phase 5b (separate plan) because the editor-protocol surface area deserves its own scoping.

## What ships

**Public JS API:**
- `format(source) → string` — lossless canonical formatter, idempotent
- `exportJson(ir, opts?)` — deterministic JSON IR export with span/precision options
- `exportMidi(ir) → Uint8Array` — Standard MIDI File Type 1; honors `@midi_channel`/`@midi_program`
- `audioBufferToWav(buffer)` / `renderToWav(ir, ctx)` — WAV encoder + offline-render integration via user-provided `OfflineAudioContext`
- `generateDocs(source, opts?)` — Markdown emitter from `///` doc comments
- `Composition.update(newIR)` — hot-reload swap (live coding)

**`synth` CLI:**
- `synth fmt [path] [-i]` — print formatted source (or write back with `-i`)
- `synth check [path]` — parse + compile; exit 1 on errors with diagnostics
- `synth json [path] [--include-spans] [--compact]` — emit IR as JSON
- `synth midi <input> -o <output>` — write MIDI file
- `synth doc [path] [--title T] [-o <output>]` — emit Markdown
- `synth help`

## Stats

- 689 tests across 44 test files (was 602 at end of Phase 4)
- Coverage: 91.93% lines / 95.45% functions / 85.15% branches / 91.93% statements
- 9 commits on the branch
- Tag: `v2.0.0-alpha.4`

## Test plan

- [x] typecheck 0
- [x] lint 0
- [x] tests 689/689
- [x] build emits ESM + CJS + .d.ts + cli.js
- [x] coverage all thresholds met
- [x] CLI tests run via subprocess against built `dist/cli.js` (gated by `existsSync` skipIf)

## Deferred

- **LSP server** (Phase 5b — diagnostics, hover, autocomplete, go-to-def, rename, extract/inline motif)
- **`synth render`** CLI command — needs `OfflineAudioContext` adapter (browser native or `node-web-audio-api` peer dep). The `renderToWav` JS function is shipped; CLI wrapper deferred to Phase 6.
- **Voice-level annotation propagation** — `voice melody { @midi_channel(2) ... }` doesn't propagate to event annotations in the IR emitter today; users place the annotation on the voice declaration prefix instead. Worth a Phase 2 follow-up.

## Phase progress

- ✅ Phase 1 — lexer/parser/AST (191)
- ✅ Phase 2 — semantic/IR (448)
- ✅ Phase 3 — Web Audio runtime (558)
- ✅ Phase 4 — effect polish + lifecycle (602)
- ✅ Phase 5 — tooling (this PR, 689)
- ⏳ Phase 5b — LSP server
- ⏳ Phase 6 — stdlib + demo

## Spec references

- Phase 5 plan: `~/Code/personal/docs/2026-04-26-synthjs-v2-redesign-phase-5-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)