### PR TITLE
v2 redesign — Phase 6: stdlib, render CLI, demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [2.0.0-alpha.5] — 2026-04-26
+
+### Added
+- **Standard library** (`src/stdlib/`) embedded as TypeScript string constants. Five modules:
+  - `@stdlib/scales` — `major_scale`, `minor_scale`, `pentatonic_major`, `pentatonic_minor`, `blues`, `dorian_scale`, `mixolydian_scale`
+  - `@stdlib/chords` — `triad_major`, `triad_minor`, `triad_dim`, `triad_aug`, `triad_sus2`, `triad_sus4`, `seventh_major`, `seventh_dom`, `seventh_minor`, `seventh_half_dim`, `seventh_dim`
+  - `@stdlib/drums` — `kick_drum`, `snare_drum`, `hat_closed`, `hat_open`, `tom_low`, `tom_high` instruments
+  - `@stdlib/instruments` — `warm_pad`, `lead_saw`, `brass`, `bass_synth`, `bell`, `string_pad`
+  - `@stdlib/fx` — documentation only (block-parameter motifs not yet supported)
+- **`synth render` CLI** for offline WAV export. Uses `node-web-audio-api` as optional peer dependency with graceful fallback message.
+- **Web demo** (`demo/`) — single-file HTML/JS/CSS playground with six pre-baked examples (scale, chord progression, two-voice, custom instrument, slide chain, dynamics).
+
+### Fixed
+- Parser: bare identifiers followed by `+` or `-` and an integer now route to pitch arithmetic (ParamRef + arith) instead of motif-reference. Stdlib motifs like `major_scale(root)` (which use `root+2`, `root+4`, etc.) now parse correctly.
+
+### Changed
+- `compileSync` inlines `\use "@stdlib/..."` declarations synchronously. Relative imports (`./shared.synth`) still require async `compile()`.
+
 ## [2.0.0-alpha.4] — 2026-04-26
 
 ### Added

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,40 @@
+# SynthJS Demo
+
+Interactive web playground. Edit source, press Play.
+
+## Run locally
+
+```bash
+# 1. Build the package (so dist/index.js exists)
+pnpm build
+
+# 2. Serve the project root from any static server. Examples:
+python3 -m http.server 8080
+# or
+npx serve .
+# or
+caddy file-server --listen :8080
+```
+
+Open http://localhost:8080/demo/ in a browser.
+
+## Examples
+
+The dropdown loads pre-baked sources for:
+
+- **C Major Scale** — scale-degree pitches with `\key`
+- **Chord Progression** — `@stdlib/chords` import + parameterized chord motifs
+- **Two Voices** — independent bass and melody, melody under reverb
+- **Custom Instrument** — `@stdlib/instruments` warm pad + four-voicing pads
+- **Slide Chain** — `linearRampToValueAtTime` glides
+- **Dynamics & Articulation** — `ramp(\\p, \\ff) { ... }` plus articulation marks
+
+## How it works
+
+`demo/main.js` imports `compileSync` and `Composition` directly from `../dist/index.js`. No bundler. The demo runs in any modern browser via plain ESM.
+
+Audio playback uses the browser's native `AudioContext`. Browsers require a user gesture (button click) before playing audio — pressing Play satisfies that.
+
+## Hosting
+
+The `demo/` directory plus the built `dist/` directory together form a self-contained static site. Drop both into GitHub Pages, Netlify, Cloudflare Pages, or any static host.

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SynthJS — Live Editor</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <h1>SynthJS</h1>
+    <p>Web-native music DSL. Edit source. Press Play.</p>
+  </header>
+  <main>
+    <div class="controls-row">
+      <label class="examples">Examples:
+        <select id="examples">
+          <option value="scale">C Major Scale</option>
+          <option value="chords">Chord Progression</option>
+          <option value="two-voice">Two Voices</option>
+          <option value="custom-instrument">Custom Instrument</option>
+          <option value="slide">Slide Chain</option>
+          <option value="dynamics">Dynamics &amp; Articulation</option>
+        </select>
+      </label>
+      <div class="buttons">
+        <button id="play">▶ Play</button>
+        <button id="stop">■ Stop</button>
+      </div>
+    </div>
+    <textarea id="source" rows="20" spellcheck="false"></textarea>
+    <div id="diagnostics" aria-live="polite"></div>
+    <p class="hint">Output is muted until first user gesture (browser policy). Click Play to allow audio.</p>
+  </main>
+  <footer>
+    <p>SynthJS v2 — <a href="https://github.com/brandonmailhiot/SynthJS">GitHub</a></p>
+  </footer>
+  <script type="module" src="main.js"></script>
+</body>
+</html>

--- a/demo/main.js
+++ b/demo/main.js
@@ -1,0 +1,141 @@
+import {
+  Composition,
+  LexError,
+  ParseError,
+  ResolveError,
+  ValidationError,
+  compileSync,
+  formatError,
+} from "../dist/index.js";
+
+const examples = {
+  scale: `\\version "2.0"
+\\tempo 120
+\\key c4 major
+voice melody {
+  4 ^1 ^2 ^3 ^4 ^5 ^6 ^7 ^8
+}`,
+
+  chords: `\\version "2.0"
+\\use "@stdlib/chords"
+\\tempo 100
+voice piano {
+  triad_major(c4)
+  triad_minor(a3)
+  triad_major(f3)
+  triad_major(g3)
+}`,
+
+  "two-voice": `\\version "2.0"
+\\tempo 90
+\\time 4/4
+
+voice bass {
+  4 c2 c2 g2 g2
+}
+
+voice melody {
+  with reverb(2, 1, 0.7) {
+    8 c5 d5 e5 f5  4 g5  8 f5 e5
+    2 r
+  }
+}`,
+
+  "custom-instrument": `\\version "2.0"
+\\use "@stdlib/instruments"
+\\tempo 60
+\\instrument warm_pad
+voice pad {
+  1 <c3 e3 g3 b3>
+  1 <a2 c3 e3 g3>
+  1 <f2 a2 c3 e3>
+  1 <g2 b2 d3 f3>
+}`,
+
+  slide: `\\version "2.0"
+\\tempo 60
+voice glide {
+  2 e2 -> c3
+  2 c3 -> f4
+  8 f4 -> d3
+}`,
+
+  dynamics: `\\version "2.0"
+\\tempo 110
+
+voice melody {
+  ramp(\\p, \\ff) {
+    8 c4 d e f g a b c5
+  }
+  \\mf 4 d5 c5 b4 a4
+  ramp(\\mf, \\pp) {
+    2 g4 f4 e4
+  }
+}`,
+};
+
+const sourceEl = document.getElementById("source");
+const examplesEl = document.getElementById("examples");
+const diagsEl = document.getElementById("diagnostics");
+const playBtn = document.getElementById("play");
+const stopBtn = document.getElementById("stop");
+
+let currentComposition = null;
+
+function loadExample(name) {
+  sourceEl.value = examples[name] ?? "";
+  showDiag("");
+}
+
+function showDiag(msg) {
+  diagsEl.textContent = msg;
+  if (msg) diagsEl.classList.add("visible");
+  else diagsEl.classList.remove("visible");
+}
+
+examplesEl.addEventListener("change", () => loadExample(examplesEl.value));
+loadExample(examplesEl.value);
+
+playBtn.addEventListener("click", async () => {
+  if (currentComposition) {
+    currentComposition.stop();
+    await currentComposition.destroy();
+    currentComposition = null;
+  }
+  showDiag("");
+
+  let ir;
+  try {
+    ir = compileSync(sourceEl.value);
+  } catch (err) {
+    if (
+      err instanceof LexError ||
+      err instanceof ParseError ||
+      err instanceof ResolveError ||
+      err instanceof ValidationError
+    ) {
+      showDiag(formatError(err, sourceEl.value));
+    } else {
+      showDiag(String(err));
+    }
+    return;
+  }
+
+  if (ir.diagnostics.length > 0) {
+    const text = ir.diagnostics
+      .map((d) => `${d.severity}: ${d.message} (line ${d.span.line})`)
+      .join("\n");
+    showDiag(text);
+  }
+
+  currentComposition = new Composition(ir);
+  await currentComposition.play();
+});
+
+stopBtn.addEventListener("click", async () => {
+  if (currentComposition) {
+    currentComposition.stop();
+    await currentComposition.destroy();
+    currentComposition = null;
+  }
+});

--- a/demo/style.css
+++ b/demo/style.css
@@ -1,0 +1,123 @@
+* { box-sizing: border-box; }
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  max-width: 900px;
+  margin: 2rem auto;
+  padding: 1rem;
+  background: #1a1a1a;
+  color: #e0e0e0;
+  line-height: 1.5;
+}
+
+header h1 {
+  color: #4a90e2;
+  margin: 0 0 0.25rem 0;
+  font-size: 2.5rem;
+}
+
+header p {
+  margin: 0 0 1.5rem 0;
+  color: #888;
+}
+
+.controls-row {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+.examples {
+  flex: 1;
+  min-width: 200px;
+}
+
+.examples select {
+  padding: 0.4rem;
+  background: #2a2a2a;
+  color: #e0e0e0;
+  border: 1px solid #444;
+  border-radius: 4px;
+  font-size: 1rem;
+  width: 100%;
+  margin-top: 0.25rem;
+}
+
+.buttons {
+  display: flex;
+  gap: 0.5rem;
+}
+
+button {
+  font-size: 1rem;
+  padding: 0.5rem 1.2rem;
+  cursor: pointer;
+  background: #4a90e2;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  font-weight: 600;
+}
+
+button:hover { background: #5aa0f2; }
+button:active { background: #3a80d2; }
+
+#stop {
+  background: #555;
+}
+
+#stop:hover { background: #666; }
+
+textarea {
+  width: 100%;
+  font-family: ui-monospace, "SF Mono", Monaco, monospace;
+  font-size: 14px;
+  background: #2a2a2a;
+  color: #e0e0e0;
+  border: 1px solid #444;
+  border-radius: 4px;
+  padding: 0.75rem;
+  resize: vertical;
+}
+
+textarea:focus {
+  outline: none;
+  border-color: #4a90e2;
+}
+
+#diagnostics {
+  margin-top: 1rem;
+  padding: 0.75rem;
+  background: #2a2a2a;
+  border-left: 4px solid #c44;
+  white-space: pre-wrap;
+  font-family: ui-monospace, "SF Mono", Monaco, monospace;
+  font-size: 13px;
+  min-height: 1rem;
+  border-radius: 0 4px 4px 0;
+  display: none;
+}
+
+#diagnostics.visible {
+  display: block;
+}
+
+.hint {
+  color: #666;
+  font-size: 0.85rem;
+  margin-top: 0.5rem;
+}
+
+footer {
+  margin-top: 2rem;
+  padding-top: 1rem;
+  border-top: 1px solid #333;
+  color: #666;
+  font-size: 0.85rem;
+}
+
+footer a {
+  color: #4a90e2;
+}

--- a/src/cli/main.test.ts
+++ b/src/cli/main.test.ts
@@ -134,6 +134,29 @@ describe.skipIf(!cliAvailable)("CLI — doc", () => {
   });
 });
 
+describe.skipIf(!cliAvailable)("CLI — render", () => {
+  it("requires -o", () => {
+    const { status } = runCli(["render"], "4 c4");
+    expect(status).toBe(2);
+  });
+
+  it("missing node-web-audio-api yields exit 3 with helpful message", () => {
+    const dir = mkdtempSync(join(tmpdir(), "synth-test-"));
+    const inPath = join(dir, "in.synth");
+    const outPath = join(dir, "out.wav");
+    writeFileSync(inPath, "4 c4");
+    const { status, stderr } = runCli(["render", inPath, "-o", outPath]);
+    // node-web-audio-api is NOT installed in dev deps; expect exit 3.
+    // (If it ever IS installed, status will be 0 and a WAV will exist.)
+    if (status === 3) {
+      expect(stderr).toContain("node-web-audio-api");
+    } else {
+      expect(status).toBe(0);
+      expect(existsSync(outPath)).toBe(true);
+    }
+  });
+});
+
 describe.skipIf(!cliAvailable)("CLI — unknown command", () => {
   it("exits 2", () => {
     const { status, stderr } = runCli(["nonexistent"]);

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -160,7 +160,11 @@ async function runRender(args: string[]): Promise<number> {
   const ir = tryCompile(source, inPath ?? "stdin");
   if (!ir) return 1;
 
-  let OfflineAudioContextCtor: new (channels: number, length: number, sampleRate: number) => unknown;
+  let OfflineAudioContextCtor: new (
+    channels: number,
+    length: number,
+    sampleRate: number,
+  ) => unknown;
   try {
     // Dynamic import via runtime string to avoid build-time type resolution.
     const modName = "node-web-audio-api";

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -10,6 +10,7 @@ import {
   format,
   formatError,
   generateDocs,
+  renderToWav,
 } from "../index.js";
 
 function readInput(path?: string): string {
@@ -131,6 +132,69 @@ function runDoc(args: string[]): number {
   return 0;
 }
 
+async function runRender(args: string[]): Promise<number> {
+  let outPath: string | undefined;
+  let inPath: string | undefined;
+  let sampleRate = 44100;
+  let channels = 2;
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === "-o") {
+      outPath = args[i + 1];
+      i++;
+    } else if (a === "--sample-rate") {
+      sampleRate = Number.parseInt(args[i + 1] ?? "44100", 10);
+      i++;
+    } else if (a === "--channels") {
+      channels = Number.parseInt(args[i + 1] ?? "2", 10);
+      i++;
+    } else if (a && !a.startsWith("-")) {
+      inPath = a;
+    }
+  }
+  if (!outPath) {
+    process.stderr.write("render: -o <output> required\n");
+    return 2;
+  }
+  const source = readInput(inPath);
+  const ir = tryCompile(source, inPath ?? "stdin");
+  if (!ir) return 1;
+
+  let OfflineAudioContextCtor: new (channels: number, length: number, sampleRate: number) => unknown;
+  try {
+    // Dynamic import via runtime string to avoid build-time type resolution.
+    const modName = "node-web-audio-api";
+    const mod = (await import(modName)) as unknown as {
+      OfflineAudioContext: new (c: number, l: number, sr: number) => unknown;
+    };
+    OfflineAudioContextCtor = mod.OfflineAudioContext;
+  } catch {
+    process.stderr.write(
+      "render requires 'node-web-audio-api' as an optional peer dependency.\n" +
+        "Install it: pnpm add -D node-web-audio-api\n",
+    );
+    return 3;
+  }
+
+  let durationSec = 0;
+  for (const voice of ir.voices) {
+    for (const ev of voice.events) {
+      const end = (ev.startBeat + ev.durationBeats) * 4 * (60 / ir.tempo);
+      if (end > durationSec) durationSec = end;
+    }
+  }
+  durationSec = Math.max(1, durationSec + 0.5);
+
+  const ctx = new OfflineAudioContextCtor(
+    channels,
+    Math.ceil(durationSec * sampleRate),
+    sampleRate,
+  ) as Parameters<typeof renderToWav>[1];
+  const wavBytes = await renderToWav(ir, ctx);
+  writeFileSync(outPath, wavBytes);
+  return 0;
+}
+
 function printHelp(): number {
   process.stdout.write(`synth — SynthJS CLI
 
@@ -143,6 +207,8 @@ COMMANDS:
   json [path] [--include-spans] [--compact]
                              Emit CompositionIR as JSON.
   midi <input> -o <output>   Export to MIDI file.
+  render <input> -o <output> [--sample-rate N] [--channels N]
+                             Render to WAV file (requires node-web-audio-api).
   doc [path] [--title T] [-o <output>]
                              Generate Markdown docs from /// comments.
   help                       Show this help.
@@ -153,31 +219,28 @@ COMMANDS:
 const args = process.argv.slice(2);
 const cmd = args[0];
 
-let exitCode: number;
-switch (cmd) {
-  case "fmt":
-    exitCode = runFmt(args.slice(1));
-    break;
-  case "check":
-    exitCode = runCheck(args.slice(1));
-    break;
-  case "json":
-    exitCode = runJson(args.slice(1));
-    break;
-  case "midi":
-    exitCode = runMidi(args.slice(1));
-    break;
-  case "doc":
-    exitCode = runDoc(args.slice(1));
-    break;
-  case "help":
-  case "--help":
-  case undefined:
-    exitCode = printHelp();
-    break;
-  default:
-    process.stderr.write(`unknown command '${cmd}'. Run 'synth help'.\n`);
-    exitCode = 2;
+async function main(): Promise<number> {
+  switch (cmd) {
+    case "fmt":
+      return runFmt(args.slice(1));
+    case "check":
+      return runCheck(args.slice(1));
+    case "json":
+      return runJson(args.slice(1));
+    case "midi":
+      return runMidi(args.slice(1));
+    case "render":
+      return runRender(args.slice(1));
+    case "doc":
+      return runDoc(args.slice(1));
+    case "help":
+    case "--help":
+    case undefined:
+      return printHelp();
+    default:
+      process.stderr.write(`unknown command '${cmd}'. Run 'synth help'.\n`);
+      return 2;
+  }
 }
 
-process.exit(exitCode);
+main().then((code) => process.exit(code));

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,6 +104,9 @@ export type {
   Diagnostic,
 } from "./ir/nodes.js";
 
+// Stdlib
+export { isStdlibPath, getStdlibSource, STDLIB } from "./stdlib/index.js";
+
 // Tools
 export { exportJson, type JsonExportOptions } from "./tools/export-json.js";
 export { exportMidi } from "./tools/export-midi.js";

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -569,6 +569,12 @@ class Parser {
       // (but not if followed by '(' which would make it a function call)
       if (isNoteLetter(tok.value) && !this.check("LParen", 1))
         return this.parsePitchEvent(undefined);
+      // ParamRef with pitch arithmetic: ident '+/-' int → pitch event
+      if (
+        (this.check("Plus", 1) || this.check("Minus", 1)) &&
+        this.check("IntLiteral", 2)
+      )
+        return this.parsePitchEvent(undefined);
       return this.parseCallOrRef();
     }
 

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -570,10 +570,7 @@ class Parser {
       if (isNoteLetter(tok.value) && !this.check("LParen", 1))
         return this.parsePitchEvent(undefined);
       // ParamRef with pitch arithmetic: ident '+/-' int → pitch event
-      if (
-        (this.check("Plus", 1) || this.check("Minus", 1)) &&
-        this.check("IntLiteral", 2)
-      )
+      if ((this.check("Plus", 1) || this.check("Minus", 1)) && this.check("IntLiteral", 2))
         return this.parsePitchEvent(undefined);
       return this.parseCallOrRef();
     }

--- a/src/semantic/module-loader.ts
+++ b/src/semantic/module-loader.ts
@@ -2,6 +2,7 @@ import type { Composition, UseDecl } from "../ast/nodes.js";
 import { ResolveError } from "../errors.js";
 import { lex } from "../lexer/lexer.js";
 import { parse } from "../parser/parser.js";
+import { getStdlibSource, isStdlibPath } from "../stdlib/index.js";
 
 export type FileResolver = (path: string) => Promise<string>;
 
@@ -18,7 +19,10 @@ export type LoadResult = LoadedModule & {
 export class ModuleLoader {
   private cache = new Map<string, LoadedModule>();
 
-  constructor(private readonly resolveFile: FileResolver) {}
+  constructor(
+    private readonly resolveFile: FileResolver,
+    private readonly opts: { useStdlib?: boolean } = {},
+  ) {}
 
   async load(entryPath: string): Promise<LoadResult> {
     const visiting = new Set<string>();
@@ -43,7 +47,12 @@ export class ModuleLoader {
     }
     visiting.add(path);
 
-    const src = await this.resolveFile(path);
+    let src: string;
+    if (this.opts.useStdlib !== false && isStdlibPath(path)) {
+      src = getStdlibSource(path) ?? "";
+    } else {
+      src = await this.resolveFile(path);
+    }
     const ast = parse(lex(src));
     const useDecls = ast.body.filter((n): n is UseDecl => n.kind === "UseDecl");
     const imports = useDecls.map((u) => ({

--- a/src/semantic/pipeline.ts
+++ b/src/semantic/pipeline.ts
@@ -1,9 +1,9 @@
+import type { Composition, TopLevel, UseDecl } from "../ast/nodes.js";
 import { emitIR } from "../ir/emit.js";
 import type { CompositionIR } from "../ir/nodes.js";
 import { lex } from "../lexer/lexer.js";
 import { parse } from "../parser/parser.js";
 import { getStdlibSource, isStdlibPath } from "../stdlib/index.js";
-import type { Composition, TopLevel, UseDecl } from "../ast/nodes.js";
 import { expandRepeats } from "./expand-repeats.js";
 import { lowerEffects } from "./lower-effects.js";
 import { lowerPitch } from "./lower-pitch.js";
@@ -33,7 +33,7 @@ function inlineStdlibImports(ast: Composition): Composition {
 
   if (userUses.length > 0) {
     throw new Error(
-      `compileSync does not support relative \\use imports (only @stdlib/...). Use compile() instead.`,
+      "compileSync does not support relative \\use imports (only @stdlib/...). Use compile() instead.",
     );
   }
 

--- a/src/semantic/pipeline.ts
+++ b/src/semantic/pipeline.ts
@@ -2,6 +2,8 @@ import { emitIR } from "../ir/emit.js";
 import type { CompositionIR } from "../ir/nodes.js";
 import { lex } from "../lexer/lexer.js";
 import { parse } from "../parser/parser.js";
+import { getStdlibSource, isStdlibPath } from "../stdlib/index.js";
+import type { Composition, TopLevel, UseDecl } from "../ast/nodes.js";
 import { expandRepeats } from "./expand-repeats.js";
 import { lowerEffects } from "./lower-effects.js";
 import { lowerPitch } from "./lower-pitch.js";
@@ -15,8 +17,53 @@ export type CompileOptions = {
   entryPath?: string;
 };
 
+function inlineStdlibImports(ast: Composition): Composition {
+  const otherTopLevels: TopLevel[] = [];
+  const stdlibUses: UseDecl[] = [];
+  const userUses: UseDecl[] = [];
+
+  for (const node of ast.body) {
+    if (node.kind === "UseDecl") {
+      if (isStdlibPath(node.path)) stdlibUses.push(node);
+      else userUses.push(node);
+    } else {
+      otherTopLevels.push(node);
+    }
+  }
+
+  if (userUses.length > 0) {
+    throw new Error(
+      `compileSync does not support relative \\use imports (only @stdlib/...). Use compile() instead.`,
+    );
+  }
+
+  const inlinedBindings: TopLevel[] = [];
+  for (const use of stdlibUses) {
+    if (use.alias) {
+      throw new Error(
+        "compileSync stdlib imports don't support 'as' aliasing yet — use plain or selective form",
+      );
+    }
+    const src = getStdlibSource(use.path);
+    if (!src) continue;
+    const stdlibAst = parse(lex(src));
+    for (const node of stdlibAst.body) {
+      if (node.kind === "Binding" || node.kind === "InstrumentDef") {
+        if (use.selected && !use.selected.includes(node.name)) continue;
+        inlinedBindings.push(node);
+      }
+    }
+  }
+
+  return {
+    ...ast,
+    body: [...inlinedBindings, ...otherTopLevels],
+  };
+}
+
 export function compileSync(source: string): CompositionIR {
-  const ast = parse(lex(source));
+  let ast = parse(lex(source));
+  ast = inlineStdlibImports(ast);
   const { symbolTable } = resolve(ast);
   let lowered = lowerSticky(ast).ast;
   lowered = lowerPitch(lowered, symbolTable).ast;
@@ -37,7 +84,7 @@ export async function compile(source: string, opts: CompileOptions = {}): Promis
     if (p === entryPath) return source;
     return fileResolver(p);
   };
-  const wrappedLoader = new ModuleLoader(wrappedResolver);
+  const wrappedLoader = new ModuleLoader(wrappedResolver, { useStdlib: true });
   const loadResult = await wrappedLoader.load(entryPath);
   const { symbolTable } = await resolveWithImports(loadResult.ast, loadResult.modules);
   let lowered = lowerSticky(loadResult.ast).ast;

--- a/src/stdlib/chords.ts
+++ b/src/stdlib/chords.ts
@@ -1,0 +1,35 @@
+export const CHORDS_SOURCE = `\\version "2.0"
+
+/// Major triad: root, +4, +7
+triad_major(root) = 4 <root root+4 root+7>
+
+/// Minor triad: root, +3, +7
+triad_minor(root) = 4 <root root+3 root+7>
+
+/// Diminished triad: root, +3, +6
+triad_dim(root) = 4 <root root+3 root+6>
+
+/// Augmented triad: root, +4, +8
+triad_aug(root) = 4 <root root+4 root+8>
+
+/// Sus2 chord: root, +2, +7
+triad_sus2(root) = 4 <root root+2 root+7>
+
+/// Sus4 chord: root, +5, +7
+triad_sus4(root) = 4 <root root+5 root+7>
+
+/// Major 7th: root, +4, +7, +11
+seventh_major(root) = 4 <root root+4 root+7 root+11>
+
+/// Dominant 7th: root, +4, +7, +10
+seventh_dom(root) = 4 <root root+4 root+7 root+10>
+
+/// Minor 7th: root, +3, +7, +10
+seventh_minor(root) = 4 <root root+3 root+7 root+10>
+
+/// Half-diminished 7th: root, +3, +6, +10
+seventh_half_dim(root) = 4 <root root+3 root+6 root+10>
+
+/// Diminished 7th: root, +3, +6, +9
+seventh_dim(root) = 4 <root root+3 root+6 root+9>
+`;

--- a/src/stdlib/drums.ts
+++ b/src/stdlib/drums.ts
@@ -1,0 +1,46 @@
+export const DRUMS_SOURCE = `\\version "2.0"
+
+/// Kick drum — low sine, fast attack, fast decay
+instrument define kick_drum {
+  oscillator sine
+  envelope percussive(0.001, 0.15)
+  detune -1200
+}
+
+/// Snare drum — square + highpass
+instrument define snare_drum {
+  oscillator square
+  envelope percussive(0.001, 0.08)
+  filter highpass(800, 1.0)
+}
+
+/// Closed hi-hat — square + highpass, very short decay
+instrument define hat_closed {
+  oscillator square
+  envelope percussive(0.0005, 0.03)
+  filter highpass(8000, 0.8)
+  detune 1200
+}
+
+/// Open hi-hat — same as closed but longer decay
+instrument define hat_open {
+  oscillator square
+  envelope percussive(0.0005, 0.25)
+  filter highpass(8000, 0.8)
+  detune 1200
+}
+
+/// Tom (low) — sine pitched down
+instrument define tom_low {
+  oscillator sine
+  envelope percussive(0.005, 0.3)
+  detune -800
+}
+
+/// Tom (high) — sine slightly pitched down
+instrument define tom_high {
+  oscillator sine
+  envelope percussive(0.005, 0.3)
+  detune -300
+}
+`;

--- a/src/stdlib/fx.ts
+++ b/src/stdlib/fx.ts
@@ -1,0 +1,13 @@
+export const FX_SOURCE = `\\version "2.0"
+
+// @stdlib/fx — effect presets (use inline)
+//
+//   with reverb(2, 3.0, 0.85) { ... }    // hall reverb
+//   with reverb(2, 0.8, 0.7)  { ... }    // room reverb
+//   with delay(0.4, 0.45)     { ... }    // tape delay
+//   with chorus(0.3, 0.005, 0.5) { ... } // chorus pad
+//   with distortion(15, "2x") { ... }    // warm drive
+//
+// Block-parameter motifs that wrap effects (planned for v2.x) will
+// expose these as named macros.
+`;

--- a/src/stdlib/index.test.ts
+++ b/src/stdlib/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { STDLIB, isStdlibPath, getStdlibSource } from "./index.js";
+import { STDLIB, getStdlibSource, isStdlibPath } from "./index.js";
 
 describe("STDLIB registry", () => {
   it("contains all five stdlib modules", () => {
@@ -34,9 +34,9 @@ describe("STDLIB registry", () => {
     const { lex } = await import("../lexer/lexer.js");
     const { parse } = await import("../parser/parser.js");
     for (const path of Object.keys(STDLIB)) {
-      const src = getStdlibSource(path);
-      expect(src).toBeDefined();
-      expect(() => parse(lex(src!))).not.toThrow();
+      const src = getStdlibSource(path) ?? "";
+      expect(src).not.toBe("");
+      expect(() => parse(lex(src))).not.toThrow();
     }
   });
 });

--- a/src/stdlib/index.test.ts
+++ b/src/stdlib/index.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { STDLIB, isStdlibPath, getStdlibSource } from "./index.js";
+
+describe("STDLIB registry", () => {
+  it("contains all five stdlib modules", () => {
+    expect(Object.keys(STDLIB).sort()).toEqual([
+      "@stdlib/chords",
+      "@stdlib/drums",
+      "@stdlib/fx",
+      "@stdlib/instruments",
+      "@stdlib/scales",
+    ]);
+  });
+
+  it("isStdlibPath accepts known paths", () => {
+    expect(isStdlibPath("@stdlib/scales")).toBe(true);
+    expect(isStdlibPath("@stdlib/instruments")).toBe(true);
+  });
+
+  it("isStdlibPath rejects others", () => {
+    expect(isStdlibPath("./foo.synth")).toBe(false);
+    expect(isStdlibPath("@stdlib/unknown")).toBe(false);
+  });
+
+  it("getStdlibSource returns content", () => {
+    expect(getStdlibSource("@stdlib/scales")).toContain("major_scale");
+  });
+
+  it("getStdlibSource returns undefined for unknown", () => {
+    expect(getStdlibSource("@stdlib/unknown")).toBeUndefined();
+  });
+
+  it("each stdlib source parses cleanly", async () => {
+    const { lex } = await import("../lexer/lexer.js");
+    const { parse } = await import("../parser/parser.js");
+    for (const path of Object.keys(STDLIB)) {
+      const src = getStdlibSource(path);
+      expect(src).toBeDefined();
+      expect(() => parse(lex(src!))).not.toThrow();
+    }
+  });
+});

--- a/src/stdlib/index.ts
+++ b/src/stdlib/index.ts
@@ -1,0 +1,27 @@
+import { CHORDS_SOURCE } from "./chords.js";
+import { DRUMS_SOURCE } from "./drums.js";
+import { FX_SOURCE } from "./fx.js";
+import { INSTRUMENTS_SOURCE } from "./instruments.js";
+import { SCALES_SOURCE } from "./scales.js";
+
+export const STDLIB: Record<string, string> = {
+  "@stdlib/scales": SCALES_SOURCE,
+  "@stdlib/chords": CHORDS_SOURCE,
+  "@stdlib/drums": DRUMS_SOURCE,
+  "@stdlib/instruments": INSTRUMENTS_SOURCE,
+  "@stdlib/fx": FX_SOURCE,
+};
+
+export function isStdlibPath(path: string): boolean {
+  return Object.hasOwn(STDLIB, path);
+}
+
+export function getStdlibSource(path: string): string | undefined {
+  return STDLIB[path];
+}
+
+export { SCALES_SOURCE } from "./scales.js";
+export { CHORDS_SOURCE } from "./chords.js";
+export { DRUMS_SOURCE } from "./drums.js";
+export { INSTRUMENTS_SOURCE } from "./instruments.js";
+export { FX_SOURCE } from "./fx.js";

--- a/src/stdlib/instruments.ts
+++ b/src/stdlib/instruments.ts
@@ -1,0 +1,47 @@
+export const INSTRUMENTS_SOURCE = `\\version "2.0"
+
+/// Mellow sawtooth pad with slight detune
+instrument define warm_pad {
+  oscillator sawtooth
+  envelope adsr(0.3, 0.4, 0.7, 1.2)
+  filter lowpass(1500, 0.4)
+  detune 5
+}
+
+/// Bright lead saw with fast attack
+instrument define lead_saw {
+  oscillator sawtooth
+  envelope adsr(0.005, 0.1, 0.8, 0.2)
+  filter lowpass(4000, 0.7)
+}
+
+/// Brass-like square with bandpass
+instrument define brass {
+  oscillator square
+  envelope adsr(0.05, 0.2, 0.7, 0.3)
+  filter bandpass(2000, 0.5)
+  detune -3
+}
+
+/// Bass synth — low square, short release
+instrument define bass_synth {
+  oscillator square
+  envelope adsr(0.005, 0.1, 0.6, 0.1)
+  filter lowpass(1000, 1.2)
+  detune -1200
+}
+
+/// Bell — fast attack, long decay
+instrument define bell {
+  oscillator sine
+  envelope adsr(0.001, 0.4, 0.2, 1.5)
+  detune 7
+}
+
+/// String pad — slow attack, full sustain
+instrument define string_pad {
+  oscillator triangle
+  envelope adsr(0.5, 0.3, 0.9, 1.0)
+  filter lowpass(3000, 0.4)
+}
+`;

--- a/src/stdlib/integration.test.ts
+++ b/src/stdlib/integration.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { compileSync } from "../index.js";
+
+describe("stdlib end-to-end via compileSync", () => {
+  it("\\use @stdlib/scales + major_scale", () => {
+    const ir = compileSync(`\\version "2.0"
+\\use "@stdlib/scales"
+\\tempo 60
+major_scale(c4)`);
+    expect(ir.voices[0]?.events.length).toBeGreaterThan(0);
+  });
+
+  it("\\use @stdlib/chords + triad_major produces chord", () => {
+    const ir = compileSync(`\\use "@stdlib/chords"
+4 c4
+triad_major(c4)`);
+    const events = ir.voices[0]?.events;
+    expect(events && events.length).toBeGreaterThan(0);
+    // Should include a chord (3 frequencies)
+    const chordEv = events?.find((e) => e.frequencies.length === 3);
+    expect(chordEv).toBeDefined();
+  });
+
+  it("\\use @stdlib/instruments + custom instrument applied", () => {
+    const ir = compileSync(`\\use "@stdlib/instruments"
+\\instrument warm_pad
+4 c4`);
+    const ev = ir.voices[0]?.events[0];
+    expect(ev?.instrument.oscillator).toBe("sawtooth");
+    expect(ev?.instrument.detune).toBe(5);
+  });
+
+  it("\\use @stdlib/drums kick_drum applied", () => {
+    const ir = compileSync(`\\use "@stdlib/drums"
+\\instrument kick_drum
+16 c2`);
+    const ev = ir.voices[0]?.events[0];
+    expect(ev?.instrument.oscillator).toBe("sine");
+    expect(ev?.instrument.detune).toBe(-1200);
+  });
+
+  it("selective \\use brings only named", () => {
+    const ir = compileSync(`\\use "@stdlib/chords" (triad_major)
+4 c4
+triad_major(c4)`);
+    expect(ir.voices[0]?.events.length).toBeGreaterThan(0);
+    // triad_minor not visible — would throw if used:
+    expect(() =>
+      compileSync(`\\use "@stdlib/chords" (triad_major)
+triad_minor(c4)`),
+    ).toThrow();
+  });
+
+  it("compileSync rejects relative \\use", () => {
+    expect(() =>
+      compileSync(`\\use "./shared.synth"
+4 c4`),
+    ).toThrow(/compile\(\)/);
+  });
+
+  it("compileSync rejects aliased stdlib imports", () => {
+    expect(() =>
+      compileSync(`\\use "@stdlib/scales" as s
+4 c4`),
+    ).toThrow();
+  });
+});

--- a/src/stdlib/integration.test.ts
+++ b/src/stdlib/integration.test.ts
@@ -15,7 +15,7 @@ major_scale(c4)`);
 4 c4
 triad_major(c4)`);
     const events = ir.voices[0]?.events;
-    expect(events && events.length).toBeGreaterThan(0);
+    expect(events?.length).toBeGreaterThan(0);
     // Should include a chord (3 frequencies)
     const chordEv = events?.find((e) => e.frequencies.length === 3);
     expect(chordEv).toBeDefined();

--- a/src/stdlib/scales.ts
+++ b/src/stdlib/scales.ts
@@ -1,0 +1,23 @@
+export const SCALES_SOURCE = `\\version "2.0"
+
+/// Major scale (Ionian) — 8-note ascending
+major_scale(root) = 4 root root+2 root+4 root+5 root+7 root+9 root+11 root+12
+
+/// Natural minor scale (Aeolian)
+minor_scale(root) = 4 root root+2 root+3 root+5 root+7 root+8 root+10 root+12
+
+/// Pentatonic major
+pentatonic_major(root) = 4 root root+2 root+4 root+7 root+9 root+12
+
+/// Pentatonic minor
+pentatonic_minor(root) = 4 root root+3 root+5 root+7 root+10 root+12
+
+/// Blues scale
+blues(root) = 4 root root+3 root+5 root+6 root+7 root+10 root+12
+
+/// Dorian mode
+dorian_scale(root) = 4 root root+2 root+3 root+5 root+7 root+9 root+10 root+12
+
+/// Mixolydian mode
+mixolydian_scale(root) = 4 root root+2 root+4 root+5 root+7 root+9 root+10 root+12
+`;


### PR DESCRIPTION
## Summary

Phase 6 makes SynthJS usable end-to-end. Ships standard library (5 modules), `synth render` CLI, web demo. Plus a parser fix for pitch arithmetic on parameter references.

## What ships

**Standard library (`@stdlib/...`)** — embedded as TypeScript string constants, no per-project setup:
- `@stdlib/scales` — 7 scales (major, minor, pentatonic major/minor, blues, dorian, mixolydian)
- `@stdlib/chords` — 11 chord motifs (triads + sevenths in major/minor/dim/aug/sus variants)
- `@stdlib/drums` — 6 percussion instruments (kick, snare, hi-hats, toms)
- `@stdlib/instruments` — 6 lead/pad instruments (warm_pad, lead_saw, brass, bass_synth, bell, string_pad)
- `@stdlib/fx` — documentation of preset effect calls

**`synth render` CLI** — offline WAV export. Uses `node-web-audio-api` as optional peer dependency with helpful fallback message.

```sh
synth render input.synth -o out.wav [--sample-rate 44100] [--channels 2]
```

**Web demo** (`demo/`) — single-file HTML/JS/CSS playground. Six pre-baked examples. Run via any static server after `pnpm build`.

## Parser fix

Bare identifiers followed by `+`/`-` and an integer now route to pitch arithmetic. Stdlib motifs like `major_scale(root) = 4 root root+2 root+4 ...` failed to parse before; fixed.

## Stats

- 704 tests across 46 test files (was 689 at end of Phase 5)
- Coverage: 92.17% lines / 85.39% branches / 95.49% functions / 92.17% statements
- 4 commits on the branch
- Tag: `v2.0.0-alpha.5`

## Test plan

- [x] typecheck 0
- [x] lint 0
- [x] tests 704/704
- [x] build emits ESM + CJS + .d.ts + cli.js
- [x] coverage thresholds met
- [x] All stdlib sources parse cleanly
- [x] Stdlib end-to-end via compileSync (scales, chords, instruments, drums, selective imports)

## Phase progress

- ✅ Phase 1 — lexer/parser/AST (191)
- ✅ Phase 2 — semantic/IR (448)
- ✅ Phase 3 — Web Audio runtime (558)
- ✅ Phase 4 — effect polish + lifecycle (602)
- ✅ Phase 5 — tooling (689)
- ✅ Phase 6 — stdlib + render CLI + demo (this PR, 704)
- ⏳ Phase 5b — LSP server (final remaining work before v2.0 stable)

## Spec references

- Phase 6 plan: `~/Code/personal/docs/2026-04-26-synthjs-v2-redesign-phase-6-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)