### PR TITLE
v2 redesign — Phase 5b: language services, LSP server, demo upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [2.0.0-alpha.6] — 2026-04-26
+
+### Added
+- **Language services** (`src/services/`) — pure-function API for editor integrations:
+  - `getDiagnostics(source)` — LSP-style diagnostics with ranges and did-you-mean suggestions
+  - `getHover(source, offset)` — hover content for pitches (frequency), motifs (signature + doc), effects, annotations, bindings, instrument defs
+  - `getCompletions(source, offset)` — context-aware completions (after `\`, `@`, `with `, `\instrument `, `\key `, default event-position)
+  - `getDefinition(source, offset)` — jump from `MotifRef`/`Call`/`\instrument` to the declaration
+  - `rename(source, offset, newName)` — list of `TextEdit`s renaming a binding/motif/instrument and all its references
+  - `offsetToPosition`, `positionToOffset`, `spanToRange` helpers
+- **`synth-lsp` binary** — minimal LSP server over stdio using JSON-RPC. Implements `initialize`, `textDocument/didOpen|didChange|didClose|hover|completion|definition|rename|prepareRename`, plus auto-published diagnostics. Editors that speak LSP (VS Code, Neovim, Helix) can connect.
+- **Demo upgrade** — replaced `<textarea>` with CodeMirror 6 + extensions backed by the language services. In-editor experience:
+  - Inline error/warning highlights via lint gutter
+  - Hover tooltips with rendered markdown
+  - Context-aware autocomplete on Ctrl+Space and as you type
+  - Doc comments surfaced in hover and completion info
+  - CodeMirror loaded from esm.sh via import map; no install step beyond `pnpm build`
+
+### Changed
+- `package.json` `bin` now exports two binaries: `synth` (CLI) and `synth-lsp` (LSP server).
+- `tsup.config.ts` builds three entry points: `dist/index.js` (library), `dist/cli.js`, `dist/lsp.js`.
+
 ## [2.0.0-alpha.5] — 2026-04-26
 
 ### Added

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,6 +1,13 @@
 # SynthJS Demo
 
-Interactive web playground. Edit source, press Play.
+Interactive web playground with full LSP-style features in the editor:
+
+- 🔴 **Diagnostics** — errors and warnings highlighted inline as you type
+- 🔍 **Hover tooltips** — pitch frequencies, motif signatures + docs, effect parameters
+- ⌨️ **Autocomplete** — context-aware (after `\`, `@`, `with `, `\instrument `, etc.)
+- 📄 **Doc comments** appear in hover and completion tooltips
+
+Built on CodeMirror 6 with extensions backed by SynthJS language services (`getDiagnostics`, `getHover`, `getCompletions`).
 
 ## Run locally
 
@@ -8,15 +15,15 @@ Interactive web playground. Edit source, press Play.
 # 1. Build the package (so dist/index.js exists)
 pnpm build
 
-# 2. Serve the project root from any static server. Examples:
+# 2. Serve the project root from any static server
 python3 -m http.server 8080
 # or
 npx serve .
-# or
-caddy file-server --listen :8080
 ```
 
 Open http://localhost:8080/demo/ in a browser.
+
+CodeMirror is loaded from esm.sh — no install step needed.
 
 ## Examples
 
@@ -27,14 +34,14 @@ The dropdown loads pre-baked sources for:
 - **Two Voices** — independent bass and melody, melody under reverb
 - **Custom Instrument** — `@stdlib/instruments` warm pad + four-voicing pads
 - **Slide Chain** — `linearRampToValueAtTime` glides
-- **Dynamics & Articulation** — `ramp(\\p, \\ff) { ... }` plus articulation marks
+- **Dynamics & Articulation** — `ramp(\p, \ff) { ... }` plus articulation marks
 
 ## How it works
 
-`demo/main.js` imports `compileSync` and `Composition` directly from `../dist/index.js`. No bundler. The demo runs in any modern browser via plain ESM.
+`demo/main.js` imports `compileSync`, `Composition`, and the language services from `../dist/index.js`. `demo/lsp-extensions.js` wraps each service in a CodeMirror 6 extension (`linter`, `hoverTooltip`, `autocompletion`).
 
-Audio playback uses the browser's native `AudioContext`. Browsers require a user gesture (button click) before playing audio — pressing Play satisfies that.
+Browsers require a user gesture (button click) before playing audio — pressing Play satisfies that.
 
 ## Hosting
 
-The `demo/` directory plus the built `dist/` directory together form a self-contained static site. Drop both into GitHub Pages, Netlify, Cloudflare Pages, or any static host.
+Drop the `demo/` directory plus the built `dist/` directory into any static host (GitHub Pages, Netlify, Cloudflare Pages, etc.). The CodeMirror imports resolve via the import map in `index.html`, which fetches from esm.sh at runtime.

--- a/demo/index.html
+++ b/demo/index.html
@@ -5,11 +5,26 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>SynthJS — Live Editor</title>
   <link rel="stylesheet" href="style.css" />
+  <script type="importmap">
+  {
+    "imports": {
+      "synth-javascript": "../dist/index.js",
+      "@codemirror/state": "https://esm.sh/@codemirror/state@6.4.1",
+      "@codemirror/view": "https://esm.sh/@codemirror/view@6.26.3?deps=@codemirror/state@6.4.1",
+      "@codemirror/commands": "https://esm.sh/@codemirror/commands@6.5.0?deps=@codemirror/state@6.4.1,@codemirror/view@6.26.3",
+      "@codemirror/language": "https://esm.sh/@codemirror/language@6.10.1?deps=@codemirror/state@6.4.1,@codemirror/view@6.26.3",
+      "@codemirror/lint": "https://esm.sh/@codemirror/lint@6.5.0?deps=@codemirror/state@6.4.1,@codemirror/view@6.26.3",
+      "@codemirror/autocomplete": "https://esm.sh/@codemirror/autocomplete@6.16.0?deps=@codemirror/state@6.4.1,@codemirror/view@6.26.3,@codemirror/language@6.10.1",
+      "@codemirror/search": "https://esm.sh/@codemirror/search@6.5.6?deps=@codemirror/state@6.4.1,@codemirror/view@6.26.3",
+      "codemirror": "https://esm.sh/codemirror@6.0.1?deps=@codemirror/state@6.4.1,@codemirror/view@6.26.3,@codemirror/commands@6.5.0,@codemirror/language@6.10.1,@codemirror/lint@6.5.0,@codemirror/autocomplete@6.16.0,@codemirror/search@6.5.6"
+    }
+  }
+  </script>
 </head>
 <body>
   <header>
     <h1>SynthJS</h1>
-    <p>Web-native music DSL. Edit source. Press Play.</p>
+    <p>Web-native music DSL with live diagnostics, hover, and autocomplete.</p>
   </header>
   <main>
     <div class="controls-row">
@@ -28,8 +43,16 @@
         <button id="stop">■ Stop</button>
       </div>
     </div>
-    <textarea id="source" rows="20" spellcheck="false"></textarea>
-    <div id="diagnostics" aria-live="polite"></div>
+    <div id="editor" aria-label="SynthJS source editor"></div>
+    <div class="features">
+      <strong>Editor features:</strong>
+      <ul>
+        <li>🔴 Errors and warnings highlighted inline as you type</li>
+        <li>🔍 Hover any pitch, motif, or effect for details (frequency, signature, docs)</li>
+        <li>⌨️ Press <kbd>Ctrl</kbd>+<kbd>Space</kbd> for context-aware completions</li>
+        <li>📄 Doc comments (<code>///</code>) appear in hover and completion tooltips</li>
+      </ul>
+    </div>
     <p class="hint">Output is muted until first user gesture (browser policy). Click Play to allow audio.</p>
   </main>
   <footer>

--- a/demo/lsp-extensions.js
+++ b/demo/lsp-extensions.js
@@ -1,0 +1,112 @@
+import { autocompletion } from "@codemirror/autocomplete";
+import { linter } from "@codemirror/lint";
+import { hoverTooltip } from "@codemirror/view";
+import {
+  getCompletions,
+  getDiagnostics,
+  getHover,
+  positionToOffset,
+} from "synth-javascript";
+
+// Convert a service Position (1-indexed) into a CodeMirror offset.
+function offsetFromOneIndexed(source, pos) {
+  return positionToOffset(source, pos);
+}
+
+export function synthLinter() {
+  return linter((view) => {
+    const source = view.state.doc.toString();
+    const diags = getDiagnostics(source);
+    return diags.map((d) => {
+      const from = offsetFromOneIndexed(source, d.range.start);
+      const to = offsetFromOneIndexed(source, d.range.end);
+      const message = d.suggestion
+        ? `${d.message}\nDid you mean '${d.suggestion}'?`
+        : d.message;
+      return {
+        from: Math.min(from, to),
+        to: Math.max(from, to),
+        severity: d.severity === "error" ? "error" : d.severity === "warning" ? "warning" : "info",
+        message,
+        source: "synthjs",
+      };
+    });
+  });
+}
+
+export function synthHover() {
+  return hoverTooltip((view, pos) => {
+    const source = view.state.doc.toString();
+    const info = getHover(source, pos);
+    if (!info) return null;
+    const from = offsetFromOneIndexed(source, info.range.start);
+    const to = offsetFromOneIndexed(source, info.range.end);
+    return {
+      pos: from,
+      end: to,
+      above: true,
+      create() {
+        const dom = document.createElement("div");
+        dom.className = "cm-tooltip-cursor synth-hover";
+        for (const block of info.contents) {
+          const p = document.createElement("p");
+          p.innerHTML = renderInlineMarkdown(block);
+          dom.appendChild(p);
+        }
+        return { dom };
+      },
+    };
+  });
+}
+
+function renderInlineMarkdown(text) {
+  // Tiny inline markdown: **bold**, `code`. No HTML in source allowed.
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+    .replace(/`([^`]+)`/g, "<code>$1</code>");
+}
+
+export function synthCompletions() {
+  return autocompletion({
+    activateOnTyping: true,
+    override: [
+      (context) => {
+        const source = context.state.doc.toString();
+        const completions = getCompletions(source, context.pos);
+        if (completions.length === 0) return null;
+        // Find word boundary for the replace range
+        const word = context.matchBefore(/[\w\\@]*/);
+        const from = word ? word.from : context.pos;
+        return {
+          from,
+          options: completions.map((c) => ({
+            label: c.label,
+            type: completionTypeFor(c.kind),
+            detail: c.detail,
+            info: c.documentation,
+          })),
+          validFor: /^[\w\\@]*$/,
+        };
+      },
+    ],
+  });
+}
+
+function completionTypeFor(kind) {
+  switch (kind) {
+    case "keyword": return "keyword";
+    case "function": return "function";
+    case "variable": return "variable";
+    case "directive": return "namespace";
+    case "annotation": return "type";
+    case "pitch": return "constant";
+    case "duration": return "constant";
+    case "instrument": return "class";
+    case "effect": return "function";
+    case "mode": return "enum";
+    default: return "text";
+  }
+}

--- a/demo/main.js
+++ b/demo/main.js
@@ -1,3 +1,8 @@
+import { autocompletion, completionKeymap } from "@codemirror/autocomplete";
+import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
+import { lintGutter } from "@codemirror/lint";
+import { EditorState } from "@codemirror/state";
+import { EditorView, highlightActiveLine, keymap, lineNumbers } from "@codemirror/view";
 import {
   Composition,
   LexError,
@@ -6,7 +11,8 @@ import {
   ValidationError,
   compileSync,
   formatError,
-} from "../dist/index.js";
+} from "synth-javascript";
+import { synthCompletions, synthHover, synthLinter } from "./lsp-extensions.js";
 
 const examples = {
   scale: `\\version "2.0"
@@ -74,27 +80,55 @@ voice melody {
 }`,
 };
 
-const sourceEl = document.getElementById("source");
 const examplesEl = document.getElementById("examples");
-const diagsEl = document.getElementById("diagnostics");
 const playBtn = document.getElementById("play");
 const stopBtn = document.getElementById("stop");
+const editorParent = document.getElementById("editor");
 
 let currentComposition = null;
+let editorView = null;
+
+function buildState(initialDoc) {
+  return EditorState.create({
+    doc: initialDoc,
+    extensions: [
+      lineNumbers(),
+      history(),
+      highlightActiveLine(),
+      autocompletion(),
+      keymap.of([...defaultKeymap, ...historyKeymap, ...completionKeymap]),
+      lintGutter(),
+      synthLinter(),
+      synthHover(),
+      synthCompletions(),
+      EditorView.theme({
+        "&": { fontSize: "14px", height: "400px" },
+        ".cm-scroller": { fontFamily: "ui-monospace, 'SF Mono', Monaco, monospace" },
+        "&.cm-focused": { outline: "none" },
+      }),
+    ],
+  });
+}
 
 function loadExample(name) {
-  sourceEl.value = examples[name] ?? "";
-  showDiag("");
+  const doc = examples[name] ?? "";
+  if (editorView) {
+    editorView.dispatch({
+      changes: { from: 0, to: editorView.state.doc.length, insert: doc },
+    });
+  }
 }
 
-function showDiag(msg) {
-  diagsEl.textContent = msg;
-  if (msg) diagsEl.classList.add("visible");
-  else diagsEl.classList.remove("visible");
-}
+editorView = new EditorView({
+  state: buildState(examples[examplesEl.value]),
+  parent: editorParent,
+});
 
 examplesEl.addEventListener("change", () => loadExample(examplesEl.value));
-loadExample(examplesEl.value);
+
+function getSource() {
+  return editorView ? editorView.state.doc.toString() : "";
+}
 
 playBtn.addEventListener("click", async () => {
   if (currentComposition) {
@@ -102,11 +136,11 @@ playBtn.addEventListener("click", async () => {
     await currentComposition.destroy();
     currentComposition = null;
   }
-  showDiag("");
 
+  const source = getSource();
   let ir;
   try {
-    ir = compileSync(sourceEl.value);
+    ir = compileSync(source);
   } catch (err) {
     if (
       err instanceof LexError ||
@@ -114,18 +148,15 @@ playBtn.addEventListener("click", async () => {
       err instanceof ResolveError ||
       err instanceof ValidationError
     ) {
-      showDiag(formatError(err, sourceEl.value));
+      console.error(formatError(err, source));
     } else {
-      showDiag(String(err));
+      console.error(err);
     }
     return;
   }
 
-  if (ir.diagnostics.length > 0) {
-    const text = ir.diagnostics
-      .map((d) => `${d.severity}: ${d.message} (line ${d.span.line})`)
-      .join("\n");
-    showDiag(text);
+  for (const d of ir.diagnostics) {
+    console.warn(`${d.severity}: ${d.message} (line ${d.span.line})`);
   }
 
   currentComposition = new Composition(ir);

--- a/demo/style.css
+++ b/demo/style.css
@@ -70,38 +70,106 @@ button:active { background: #3a80d2; }
 
 #stop:hover { background: #666; }
 
-textarea {
+#editor {
   width: 100%;
-  font-family: ui-monospace, "SF Mono", Monaco, monospace;
-  font-size: 14px;
   background: #2a2a2a;
-  color: #e0e0e0;
   border: 1px solid #444;
   border-radius: 4px;
-  padding: 0.75rem;
-  resize: vertical;
+  overflow: hidden;
+  margin-bottom: 1rem;
 }
 
-textarea:focus {
-  outline: none;
-  border-color: #4a90e2;
+.cm-editor {
+  background: #2a2a2a !important;
+  color: #e0e0e0;
 }
 
-#diagnostics {
-  margin-top: 1rem;
-  padding: 0.75rem;
-  background: #2a2a2a;
-  border-left: 4px solid #c44;
-  white-space: pre-wrap;
+.cm-editor.cm-focused {
+  outline: 2px solid #4a90e2 !important;
+}
+
+.cm-gutters {
+  background: #222 !important;
+  border-right: 1px solid #444 !important;
+  color: #666 !important;
+}
+
+.cm-activeLineGutter,
+.cm-activeLine {
+  background: #333 !important;
+}
+
+.cm-tooltip {
+  background: #2f2f2f !important;
+  border: 1px solid #555 !important;
+  color: #e0e0e0 !important;
+  border-radius: 4px;
   font-family: ui-monospace, "SF Mono", Monaco, monospace;
   font-size: 13px;
-  min-height: 1rem;
-  border-radius: 0 4px 4px 0;
-  display: none;
+  padding: 0.4rem 0.6rem;
+  max-width: 480px;
 }
 
-#diagnostics.visible {
-  display: block;
+.cm-tooltip code {
+  background: #1a1a1a;
+  padding: 0 0.25rem;
+  border-radius: 3px;
+}
+
+.synth-hover p {
+  margin: 0.2rem 0;
+}
+
+.cm-tooltip.cm-tooltip-autocomplete > ul {
+  font-family: ui-monospace, "SF Mono", Monaco, monospace;
+  font-size: 13px;
+}
+
+.cm-diagnostic {
+  font-family: ui-monospace, "SF Mono", Monaco, monospace;
+  font-size: 12px;
+  white-space: pre-wrap;
+}
+
+.cm-diagnostic-error {
+  border-left-color: #c44 !important;
+}
+
+.cm-diagnostic-warning {
+  border-left-color: #d8a13c !important;
+}
+
+.features {
+  background: #232323;
+  border-left: 3px solid #4a90e2;
+  padding: 0.6rem 1rem;
+  border-radius: 0 4px 4px 0;
+  margin-bottom: 1rem;
+  font-size: 0.92rem;
+}
+
+.features ul {
+  margin: 0.4rem 0 0 0;
+  padding-left: 1.2rem;
+}
+
+.features li {
+  margin: 0.2rem 0;
+}
+
+.features kbd {
+  background: #444;
+  padding: 0 0.4rem;
+  border-radius: 3px;
+  font-family: ui-monospace, monospace;
+  font-size: 0.85rem;
+}
+
+.features code {
+  background: #1a1a1a;
+  padding: 0 0.25rem;
+  border-radius: 3px;
+  font-size: 0.85rem;
 }
 
 .hint {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     }
   },
   "bin": {
-    "synth": "./dist/cli.js"
+    "synth": "./dist/cli.js",
+    "synth-lsp": "./dist/lsp.js"
   },
   "files": [
     "dist",

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,3 +145,5 @@ export {
 } from "./services/position.js";
 export { getHover, type HoverInfo } from "./services/hover.js";
 export { getCompletions, type CompletionItem } from "./services/completion.js";
+export { getDefinition } from "./services/definition.js";
+export { rename, type TextEdit } from "./services/rename.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,3 +129,17 @@ export {
   type OfflineAudioContextLike,
   type RenderOptions,
 } from "./tools/render-wav.js";
+
+// Services
+export {
+  getDiagnostics,
+  type ServiceDiagnostic,
+  type DiagnosticSeverity,
+} from "./services/diagnostics.js";
+export {
+  offsetToPosition,
+  positionToOffset,
+  spanToRange,
+  type Position,
+  type Range,
+} from "./services/position.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,3 +143,4 @@ export {
   type Position,
   type Range,
 } from "./services/position.js";
+export { getHover, type HoverInfo } from "./services/hover.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,3 +144,4 @@ export {
   type Range,
 } from "./services/position.js";
 export { getHover, type HoverInfo } from "./services/hover.js";
+export { getCompletions, type CompletionItem } from "./services/completion.js";

--- a/src/lsp/protocol.test.ts
+++ b/src/lsp/protocol.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { frameMessage, parseMessage } from "./protocol.js";
+
+describe("frameMessage", () => {
+  it("encodes Content-Length header + JSON body", () => {
+    const out = frameMessage({ jsonrpc: "2.0", id: 1, result: null });
+    expect(out).toMatch(/Content-Length: \d+\r\n\r\n/);
+    expect(out).toContain('"jsonrpc"');
+  });
+
+  it("Content-Length matches body byte length", () => {
+    const msg = { hello: "world" };
+    const out = frameMessage(msg);
+    const m = out.match(/Content-Length: (\d+)/);
+    const reportedLen = Number.parseInt(m?.[1] ?? "0", 10);
+    const body = out.split("\r\n\r\n")[1] ?? "";
+    expect(Buffer.byteLength(body, "utf-8")).toBe(reportedLen);
+  });
+});
+
+describe("parseMessage", () => {
+  it("returns null when header incomplete", () => {
+    expect(parseMessage("Content-Length: 10")).toBeNull();
+  });
+
+  it("returns null when body short", () => {
+    expect(parseMessage("Content-Length: 100\r\n\r\nshort")).toBeNull();
+  });
+
+  it("parses well-formed message", () => {
+    const body = JSON.stringify({ a: 1 });
+    const buf = `Content-Length: ${body.length}\r\n\r\n${body}`;
+    const result = parseMessage(buf);
+    expect(result).not.toBeNull();
+    expect(result?.message).toEqual({ a: 1 });
+    expect(result?.rest).toBe("");
+  });
+
+  it("preserves rest after one parsed message", () => {
+    const body1 = JSON.stringify({ a: 1 });
+    const body2 = JSON.stringify({ b: 2 });
+    const buf = `Content-Length: ${body1.length}\r\n\r\n${body1}Content-Length: ${body2.length}\r\n\r\n${body2}`;
+    const r1 = parseMessage(buf);
+    expect(r1?.message).toEqual({ a: 1 });
+    expect(r1?.rest.length).toBeGreaterThan(0);
+    const r2 = parseMessage(r1?.rest ?? "");
+    expect(r2?.message).toEqual({ b: 2 });
+  });
+
+  it("invalid JSON returns null", () => {
+    const buf = "Content-Length: 7\r\n\r\nnot{json";
+    expect(parseMessage(buf)).toBeNull();
+  });
+});

--- a/src/lsp/protocol.ts
+++ b/src/lsp/protocol.ts
@@ -1,0 +1,25 @@
+export type ParsedMessage = { message: unknown; rest: string };
+
+export function parseMessage(buffer: string): ParsedMessage | null {
+  const headerEnd = buffer.indexOf("\r\n\r\n");
+  if (headerEnd === -1) return null;
+  const header = buffer.slice(0, headerEnd);
+  const lengthMatch = header.match(/Content-Length:\s*(\d+)/i);
+  if (!lengthMatch) return null;
+  const length = Number.parseInt(lengthMatch[1] ?? "0", 10);
+  const bodyStart = headerEnd + 4;
+  if (buffer.length < bodyStart + length) return null;
+  const bodyBytes = buffer.slice(bodyStart, bodyStart + length);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(bodyBytes);
+  } catch {
+    return null;
+  }
+  return { message: parsed, rest: buffer.slice(bodyStart + length) };
+}
+
+export function frameMessage(message: unknown): string {
+  const body = JSON.stringify(message);
+  return `Content-Length: ${Buffer.byteLength(body, "utf-8")}\r\n\r\n${body}`;
+}

--- a/src/lsp/server.test.ts
+++ b/src/lsp/server.test.ts
@@ -1,0 +1,118 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { frameMessage, parseMessage } from "./protocol.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const lspPath = join(__dirname, "../../dist/lsp.js");
+
+const lspAvailable = existsSync(lspPath);
+
+async function startLsp(): Promise<ChildProcess> {
+  const child = spawn("node", [lspPath], { stdio: ["pipe", "pipe", "pipe"] });
+  return child;
+}
+
+async function rpcCall(child: ChildProcess, message: object): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    let buf = "";
+    const handler = (data: Buffer) => {
+      buf += data.toString();
+      const parsed = parseMessage(buf);
+      if (parsed) {
+        child.stdout?.off("data", handler);
+        resolve(parsed.message);
+      }
+    };
+    child.stdout?.on("data", handler);
+    child.stderr?.once("data", (d) => reject(new Error(`stderr: ${d.toString()}`)));
+    child.stdin?.write(frameMessage(message));
+  });
+}
+
+describe.skipIf(!lspAvailable)("LSP server", () => {
+  it("responds to initialize", async () => {
+    const child = await startLsp();
+    const result = await rpcCall(child, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: { processId: process.pid, rootUri: null, capabilities: {} },
+    });
+    expect(result).toMatchObject({
+      jsonrpc: "2.0",
+      id: 1,
+      result: { capabilities: expect.objectContaining({ hoverProvider: true }) },
+    });
+    child.kill();
+  });
+
+  it("publishes diagnostics on didOpen", async () => {
+    const child = await startLsp();
+    await rpcCall(child, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: { processId: process.pid, rootUri: null, capabilities: {} },
+    });
+    // Send didOpen and wait for publishDiagnostics notification
+    return new Promise<void>((resolve, reject) => {
+      let buf = "";
+      const handler = (data: Buffer) => {
+        buf += data.toString();
+        while (true) {
+          const parsed = parseMessage(buf);
+          if (!parsed) break;
+          buf = parsed.rest;
+          const msg = parsed.message as {
+            method?: string;
+            params?: { diagnostics: unknown[] };
+          };
+          if (msg.method === "textDocument/publishDiagnostics") {
+            child.stdout?.off("data", handler);
+            expect(msg.params?.diagnostics).toBeDefined();
+            child.kill();
+            resolve();
+            return;
+          }
+        }
+      };
+      child.stdout?.on("data", handler);
+      child.stdin?.write(
+        frameMessage({
+          jsonrpc: "2.0",
+          method: "textDocument/didOpen",
+          params: {
+            textDocument: {
+              uri: "file:///test.synth",
+              languageId: "synthjs",
+              version: 1,
+              text: "4 c4 ! 4 d4",
+            },
+          },
+        }),
+      );
+      setTimeout(() => reject(new Error("timeout")), 5000);
+    });
+  });
+
+  it("responds to shutdown with null result", async () => {
+    const child = await startLsp();
+    await rpcCall(child, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: { processId: process.pid, rootUri: null, capabilities: {} },
+    });
+    const result = await rpcCall(child, {
+      jsonrpc: "2.0",
+      id: 2,
+      method: "shutdown",
+      params: null,
+    });
+    expect(result).toMatchObject({ jsonrpc: "2.0", id: 2, result: null });
+    child.kill();
+  });
+});

--- a/src/lsp/server.ts
+++ b/src/lsp/server.ts
@@ -1,0 +1,254 @@
+import {
+  getCompletions,
+  getDefinition,
+  getDiagnostics,
+  getHover,
+  offsetToPosition,
+  positionToOffset,
+  rename,
+} from "../index.js";
+import { frameMessage, parseMessage } from "./protocol.js";
+
+type RpcMessage = {
+  jsonrpc: "2.0";
+  id?: number | string;
+  method?: string;
+  params?: unknown;
+  result?: unknown;
+  error?: { code: number; message: string };
+};
+
+type LspPosition = { line: number; character: number }; // 0-indexed
+type LspRange = { start: LspPosition; end: LspPosition };
+
+class LspServer {
+  private documents = new Map<string, string>();
+  private buffer = "";
+  private shutdownReceived = false;
+
+  start(): void {
+    process.stdin.setEncoding("utf-8");
+    process.stdin.on("data", (chunk) => {
+      this.buffer += chunk.toString();
+      while (true) {
+        const parsed = parseMessage(this.buffer);
+        if (!parsed) break;
+        this.buffer = parsed.rest;
+        this.handle(parsed.message as RpcMessage);
+      }
+    });
+    process.stdin.on("end", () => process.exit(0));
+  }
+
+  private send(msg: object): void {
+    process.stdout.write(frameMessage(msg));
+  }
+
+  private respond(id: number | string | undefined, result: unknown): void {
+    if (id === undefined) return;
+    this.send({ jsonrpc: "2.0", id, result });
+  }
+
+  private notify(method: string, params: unknown): void {
+    this.send({ jsonrpc: "2.0", method, params });
+  }
+
+  private handle(msg: RpcMessage): void {
+    if (!msg.method) return;
+    switch (msg.method) {
+      case "initialize":
+        this.respond(msg.id, this.initializeResult());
+        return;
+      case "initialized":
+        return;
+      case "shutdown":
+        this.shutdownReceived = true;
+        this.respond(msg.id, null);
+        return;
+      case "exit":
+        process.exit(this.shutdownReceived ? 0 : 1);
+        break;
+      case "textDocument/didOpen":
+        this.handleDidOpen(msg.params as { textDocument: { uri: string; text: string } });
+        return;
+      case "textDocument/didChange":
+        this.handleDidChange(
+          msg.params as { textDocument: { uri: string }; contentChanges: { text: string }[] },
+        );
+        return;
+      case "textDocument/didClose":
+        this.documents.delete((msg.params as { textDocument: { uri: string } }).textDocument.uri);
+        return;
+      case "textDocument/hover":
+        this.respond(msg.id, this.handleHover(msg.params));
+        return;
+      case "textDocument/completion":
+        this.respond(msg.id, this.handleCompletion(msg.params));
+        return;
+      case "textDocument/definition":
+        this.respond(msg.id, this.handleDefinition(msg.params));
+        return;
+      case "textDocument/rename":
+        this.respond(msg.id, this.handleRename(msg.params));
+        return;
+      case "textDocument/prepareRename":
+        this.respond(msg.id, this.handlePrepareRename(msg.params));
+        return;
+      default:
+        if (msg.id !== undefined) {
+          this.send({
+            jsonrpc: "2.0",
+            id: msg.id,
+            error: { code: -32601, message: `method not found: ${msg.method}` },
+          });
+        }
+    }
+  }
+
+  private initializeResult(): object {
+    return {
+      capabilities: {
+        textDocumentSync: 1, // full sync
+        hoverProvider: true,
+        completionProvider: { triggerCharacters: ["\\", "@", " "] },
+        definitionProvider: true,
+        renameProvider: { prepareProvider: true },
+      },
+    };
+  }
+
+  private handleDidOpen(params: { textDocument: { uri: string; text: string } }): void {
+    this.documents.set(params.textDocument.uri, params.textDocument.text);
+    this.publishDiagnostics(params.textDocument.uri);
+  }
+
+  private handleDidChange(params: {
+    textDocument: { uri: string };
+    contentChanges: { text: string }[];
+  }): void {
+    const last = params.contentChanges[params.contentChanges.length - 1];
+    if (last) this.documents.set(params.textDocument.uri, last.text);
+    this.publishDiagnostics(params.textDocument.uri);
+  }
+
+  private publishDiagnostics(uri: string): void {
+    const source = this.documents.get(uri) ?? "";
+    const diags = getDiagnostics(source);
+    this.notify("textDocument/publishDiagnostics", {
+      uri,
+      diagnostics: diags.map((d) => ({
+        range: oneToZeroRange(d.range),
+        severity: severityToLsp(d.severity),
+        message: d.message + (d.suggestion ? ` (did you mean '${d.suggestion}'?)` : ""),
+        source: "synthjs",
+      })),
+    });
+  }
+
+  private getSourceAndOffset(params: unknown): { source: string; offset: number } | null {
+    const p = params as { textDocument: { uri: string }; position: LspPosition };
+    const source = this.documents.get(p.textDocument.uri);
+    if (source === undefined) return null;
+    const onePos = { line: p.position.line + 1, column: p.position.character + 1 };
+    return { source, offset: positionToOffset(source, onePos) };
+  }
+
+  private handleHover(params: unknown): unknown {
+    const ctx = this.getSourceAndOffset(params);
+    if (!ctx) return null;
+    const info = getHover(ctx.source, ctx.offset);
+    if (!info) return null;
+    return {
+      contents: { kind: "markdown", value: info.contents.join("\n\n") },
+      range: oneToZeroRange(info.range),
+    };
+  }
+
+  private handleCompletion(params: unknown): unknown {
+    const ctx = this.getSourceAndOffset(params);
+    if (!ctx) return { items: [] };
+    const items = getCompletions(ctx.source, ctx.offset).map((c) => ({
+      label: c.label,
+      kind: completionKindToLsp(c.kind),
+      detail: c.detail,
+      documentation: c.documentation,
+    }));
+    return { items, isIncomplete: false };
+  }
+
+  private handleDefinition(params: unknown): unknown {
+    const ctx = this.getSourceAndOffset(params);
+    if (!ctx) return null;
+    const range = getDefinition(ctx.source, ctx.offset);
+    if (!range) return null;
+    const p = params as { textDocument: { uri: string } };
+    return {
+      uri: p.textDocument.uri,
+      range: oneToZeroRange(range),
+    };
+  }
+
+  private handleRename(params: unknown): unknown {
+    const ctx = this.getSourceAndOffset(params);
+    if (!ctx) return null;
+    const newName = (params as { newName: string }).newName;
+    const edits = rename(ctx.source, ctx.offset, newName);
+    if (!edits) return null;
+    const p = params as { textDocument: { uri: string } };
+    return {
+      changes: {
+        [p.textDocument.uri]: edits.map((e) => ({
+          range: oneToZeroRange(e.range),
+          newText: e.newText,
+        })),
+      },
+    };
+  }
+
+  private handlePrepareRename(params: unknown): unknown {
+    const ctx = this.getSourceAndOffset(params);
+    if (!ctx) return null;
+    // Try renaming with a dummy name; if it returns edits, the cursor is on a renamable token
+    const edits = rename(ctx.source, ctx.offset, "__placeholder__");
+    if (!edits || edits.length === 0) return null;
+    // Return the first edit's range as the "rename region"
+    const first = edits[0];
+    if (!first) return null;
+    return oneToZeroRange(first.range);
+  }
+}
+
+function oneToZeroRange(r: {
+  start: { line: number; column: number };
+  end: { line: number; column: number };
+}): LspRange {
+  return {
+    start: { line: r.start.line - 1, character: r.start.column - 1 },
+    end: { line: r.end.line - 1, character: r.end.column - 1 },
+  };
+}
+
+function severityToLsp(s: "error" | "warning" | "info"): number {
+  if (s === "error") return 1;
+  if (s === "warning") return 2;
+  if (s === "info") return 3;
+  return 4; // hint
+}
+
+function completionKindToLsp(kind: string): number {
+  // Minimal mapping; LSP completion kinds 1-25
+  if (kind === "keyword") return 14;
+  if (kind === "function") return 3;
+  if (kind === "variable") return 6;
+  if (kind === "value") return 12;
+  if (kind === "directive") return 14;
+  if (kind === "annotation") return 15;
+  if (kind === "pitch") return 12;
+  if (kind === "duration") return 12;
+  if (kind === "instrument") return 7;
+  if (kind === "effect") return 3;
+  if (kind === "mode") return 12;
+  return 1;
+}
+
+new LspServer().start();

--- a/src/services/completion.test.ts
+++ b/src/services/completion.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { getCompletions } from "./completion.js";
+
+describe("getCompletions", () => {
+  it("after \\\\ suggests directives + dynamics", () => {
+    const src = "\\";
+    const items = getCompletions(src, src.length);
+    const labels = items.map((i) => i.label);
+    expect(labels).toContain("\\tempo");
+    expect(labels).toContain("\\mp");
+  });
+
+  it("after @ suggests annotation names", () => {
+    const src = "4 c4@";
+    const items = getCompletions(src, src.length);
+    const labels = items.map((i) => i.label);
+    expect(labels).toContain("@cue");
+    expect(labels).toContain("@chance");
+  });
+
+  it("after 'with ' suggests effect names", () => {
+    const src = "with ";
+    const items = getCompletions(src, src.length);
+    const labels = items.map((i) => i.label);
+    expect(labels).toContain("reverb");
+    expect(labels).toContain("delay");
+  });
+
+  it("after '\\instrument ' suggests primitives", () => {
+    const src = "\\instrument ";
+    const items = getCompletions(src, src.length);
+    const labels = items.map((i) => i.label);
+    expect(labels).toContain("sawtooth");
+    expect(labels).toContain("sine");
+  });
+
+  it("after '\\instrument ' with custom instrument in scope suggests it", () => {
+    const src = "instrument define warm { oscillator sawtooth }\n\\instrument ";
+    const items = getCompletions(src, src.length);
+    const labels = items.map((i) => i.label);
+    expect(labels).toContain("warm");
+  });
+
+  it("after '\\key ' suggests pitches", () => {
+    const src = "\\key ";
+    const items = getCompletions(src, src.length);
+    const labels = items.map((i) => i.label);
+    expect(labels).toContain("c4");
+  });
+
+  it("after '\\key c4 ' suggests modes", () => {
+    const src = "\\key c4 ";
+    const items = getCompletions(src, src.length);
+    const labels = items.map((i) => i.label);
+    expect(labels).toContain("major");
+    expect(labels).toContain("dorian");
+  });
+
+  it("default context suggests durations + pitches + bindings", () => {
+    const src = "intro = 4 c4\n";
+    const items = getCompletions(src, src.length);
+    const labels = items.map((i) => i.label);
+    expect(labels).toContain("4");
+    expect(labels).toContain("c4");
+    expect(labels).toContain("intro");
+  });
+
+  it("each item has a label and kind", () => {
+    const items = getCompletions("4 ", 2);
+    for (const item of items) {
+      expect(item.label).toBeTruthy();
+      expect(item.kind).toBeTruthy();
+    }
+  });
+
+  it("items have details where applicable", () => {
+    const items = getCompletions("with ", 5);
+    const reverb = items.find((i) => i.label === "reverb");
+    expect(reverb?.detail).toContain("channels");
+  });
+
+  it("annotation completions have kind 'annotation'", () => {
+    const src = "4 c4@";
+    const items = getCompletions(src, src.length);
+    for (const item of items) {
+      expect(item.kind).toBe("annotation");
+    }
+  });
+
+  it("directive completions include \\version and \\use", () => {
+    const src = "\\";
+    const items = getCompletions(src, src.length);
+    const labels = items.map((i) => i.label);
+    expect(labels).toContain("\\version");
+    expect(labels).toContain("\\use");
+  });
+
+  it("default context includes keywords like 'voice' and 'with'", () => {
+    const src = "";
+    const items = getCompletions(src, 0);
+    const labels = items.map((i) => i.label);
+    expect(labels).toContain("voice");
+    expect(labels).toContain("with");
+  });
+
+  it("binding doc is surfaced as documentation", () => {
+    const src = "/// the arp pattern\narp(root) = 4 root\n";
+    const items = getCompletions(src, src.length);
+    const arp = items.find((i) => i.label === "arp");
+    expect(arp).toBeDefined();
+    expect(arp?.documentation).toContain("arp pattern");
+  });
+});

--- a/src/services/completion.ts
+++ b/src/services/completion.ts
@@ -1,0 +1,196 @@
+import type { Composition, TopLevel } from "../ast/nodes.js";
+import { lex } from "../lexer/lexer.js";
+import { parse } from "../parser/parser.js";
+import { ANNOTATION_REGISTRY } from "../semantic/registries/annotations.js";
+import { EFFECT_REGISTRY } from "../semantic/registries/effects.js";
+
+export type CompletionItem = {
+  label: string;
+  kind:
+    | "keyword"
+    | "function"
+    | "variable"
+    | "value"
+    | "directive"
+    | "annotation"
+    | "pitch"
+    | "duration"
+    | "instrument"
+    | "effect"
+    | "mode";
+  detail?: string;
+  documentation?: string;
+};
+
+const PRIMITIVES = ["sine", "square", "sawtooth", "triangle"];
+const MODES = ["major", "minor", "dorian", "phrygian", "lydian", "mixolydian", "locrian"];
+const KEYWORDS = [
+  "voice",
+  "with",
+  "envelope",
+  "tuplet",
+  "repeat",
+  "ramp",
+  "as",
+  "instrument",
+  "define",
+];
+const COMMANDS = ["\\version", "\\tempo", "\\time", "\\key", "\\instrument", "\\detune", "\\use"];
+const DYNAMICS = ["\\pp", "\\p", "\\mp", "\\mf", "\\f", "\\ff", "\\fff"];
+const COMMON_DURATIONS = ["1", "2", "4", "8", "16", "32", "64", "1.", "2.", "4.", "8.", "4t", "8t"];
+const COMMON_PITCHES = [
+  "c4",
+  "d4",
+  "e4",
+  "f4",
+  "g4",
+  "a4",
+  "b4",
+  "c5",
+  "d5",
+  "e5",
+  "f5",
+  "g5",
+  "a5",
+  "b5",
+  "c3",
+  "d3",
+  "e3",
+  "f3",
+  "g3",
+  "a3",
+  "b3",
+  "c#4",
+  "d#4",
+  "f#4",
+  "g#4",
+  "a#4",
+  "r",
+];
+
+export function getCompletions(source: string, offset: number): CompletionItem[] {
+  // Look at what's immediately before the cursor
+  const before = source.slice(0, offset);
+  const prefixMatch = before.match(/(\\\w*|@\w*|\w+)$/);
+  const prefix = prefixMatch ? prefixMatch[0] : "";
+
+  // \ → directive or dynamic
+  if (prefix.startsWith("\\")) {
+    return [
+      ...COMMANDS.map((c) => ({ label: c, kind: "directive" as const })),
+      ...DYNAMICS.map((d) => ({ label: d, kind: "value" as const, detail: "dynamic" })),
+    ];
+  }
+
+  // @ → annotation
+  if (prefix.startsWith("@")) {
+    return Object.keys(ANNOTATION_REGISTRY).map((name) => {
+      const spec = ANNOTATION_REGISTRY[name];
+      if (!spec) return { label: name, kind: "annotation" as const };
+      return {
+        label: name,
+        kind: "annotation" as const,
+        detail: `(${spec.params.map((p) => `${p.name}: ${p.kind}`).join(", ")})`,
+      };
+    });
+  }
+
+  // After "with " → effect names
+  const beforeWith = before.match(/\bwith\s+(\w*)$/);
+  if (beforeWith) {
+    return Object.keys(EFFECT_REGISTRY).map((name) => {
+      const spec = EFFECT_REGISTRY[name];
+      if (!spec) return { label: name, kind: "effect" as const };
+      return {
+        label: name,
+        kind: "effect" as const,
+        detail: `(${spec.params.map((p) => `${p.name}: ${p.kind}`).join(", ")})`,
+      };
+    });
+  }
+
+  // After "\\instrument " → primitives + custom instruments
+  const beforeInstr = before.match(/\\instrument\s+(\w*)$/);
+  if (beforeInstr) {
+    const items: CompletionItem[] = PRIMITIVES.map((p) => ({
+      label: p,
+      kind: "instrument" as const,
+      detail: "primitive oscillator",
+    }));
+    const ast = tryParse(source);
+    if (ast) {
+      for (const n of ast.body) {
+        if (n.kind === "InstrumentDef") {
+          items.push({ label: n.name, kind: "instrument", detail: "custom instrument" });
+        }
+      }
+    }
+    return items;
+  }
+
+  // After "\\key <pitch> " → mode names
+  const beforeKeyMode = before.match(/\\key\s+\S+\s+(\w*)$/);
+  if (beforeKeyMode) {
+    return MODES.map((m) => ({ label: m, kind: "mode" as const }));
+  }
+
+  // After "\\key " → pitches
+  const beforeKey = before.match(/\\key\s+(\w*)$/);
+  if (beforeKey) {
+    return COMMON_PITCHES.filter((p) => p !== "r").map((p) => ({
+      label: p,
+      kind: "pitch" as const,
+    }));
+  }
+
+  // Default: event-position completions — durations, pitches, motif names, keywords
+  const items: CompletionItem[] = [];
+  for (const d of COMMON_DURATIONS) items.push({ label: d, kind: "duration" });
+  for (const p of COMMON_PITCHES) items.push({ label: p, kind: "pitch" });
+  for (const k of KEYWORDS) items.push({ label: k, kind: "keyword" });
+
+  // Add bindings from current AST
+  const ast = tryParse(source);
+  if (ast) {
+    collectBindings(ast.body, items);
+  }
+
+  return items;
+}
+
+function tryParse(source: string): Composition | null {
+  try {
+    return parse(lex(source));
+  } catch {
+    // If the full source fails, try without the last incomplete line
+    const lastNewline = source.lastIndexOf("\n");
+    if (lastNewline > 0) {
+      try {
+        return parse(lex(source.slice(0, lastNewline)));
+      } catch {
+        return null;
+      }
+    }
+    return null;
+  }
+}
+
+function collectBindings(body: TopLevel[], items: CompletionItem[]): void {
+  for (const n of body) {
+    if (n.kind === "Binding") {
+      const sig = n.params ? `${n.name}(${n.params.join(", ")})` : n.name;
+      items.push({
+        label: n.name,
+        kind: "function",
+        detail: sig,
+        ...(n.doc ? { documentation: n.doc.trim() } : {}),
+      });
+    }
+    if (n.kind === "InstrumentDef") {
+      items.push({ label: n.name, kind: "instrument", detail: "custom instrument" });
+    }
+    if (n.kind === "VoiceDecl") {
+      collectBindings(n.body.body, items);
+    }
+  }
+}

--- a/src/services/definition.test.ts
+++ b/src/services/definition.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { getDefinition } from "./definition.js";
+
+describe("getDefinition", () => {
+  it("MotifRef points to its binding", () => {
+    const src = "intro = 4 c4\nintro";
+    const offset = src.lastIndexOf("intro");
+    const range = getDefinition(src, offset);
+    expect(range).not.toBeNull();
+    // binding's span starts at offset 0, line 1
+    expect(range?.start.line).toBe(1);
+    expect(range?.start.column).toBe(1);
+  });
+
+  it("Call points to parameterized binding", () => {
+    const src = "arp(root) = 8 root\narp(c4)";
+    const offset = src.lastIndexOf("arp");
+    const range = getDefinition(src, offset);
+    expect(range).not.toBeNull();
+    expect(range?.start.line).toBe(1);
+  });
+
+  it("\\instrument primitive returns null", () => {
+    const src = "\\instrument sawtooth\n4 c4";
+    const offset = src.indexOf("sawtooth");
+    expect(getDefinition(src, offset)).toBeNull();
+  });
+
+  it("\\instrument <custom> points to InstrumentDef", () => {
+    const src = "instrument define warm { oscillator sawtooth }\n\\instrument warm\n4 c4";
+    const offset = src.lastIndexOf("warm");
+    const range = getDefinition(src, offset);
+    expect(range).not.toBeNull();
+    expect(range?.start.line).toBe(1);
+  });
+
+  it("cursor on whitespace returns null", () => {
+    const src = "intro = 4 c4";
+    expect(getDefinition(src, 6)).toBeNull(); // space before '='
+  });
+
+  it("malformed source returns null", () => {
+    expect(getDefinition("4 ,", 0)).toBeNull();
+  });
+
+  it("unresolved ref returns null", () => {
+    const src = "unknown_name";
+    expect(getDefinition(src, 0)).toBeNull();
+  });
+
+  it("returns a Range with start and end positions", () => {
+    const src = "intro = 4 c4\nintro";
+    const offset = src.lastIndexOf("intro");
+    const range = getDefinition(src, offset);
+    expect(range).not.toBeNull();
+    expect(range?.start).toBeDefined();
+    expect(range?.end).toBeDefined();
+    expect(typeof range?.start.line).toBe("number");
+    expect(typeof range?.start.column).toBe("number");
+  });
+});

--- a/src/services/definition.ts
+++ b/src/services/definition.ts
@@ -1,0 +1,102 @@
+import type { Binding, Composition, InstrumentDef, TopLevel } from "../ast/nodes.js";
+import type { SourceSpan } from "../errors.js";
+import { lex } from "../lexer/lexer.js";
+import { parse } from "../parser/parser.js";
+import { type Range, spanToRange } from "./position.js";
+
+export function getDefinition(source: string, offset: number): Range | null {
+  let ast: Composition;
+  try {
+    ast = parse(lex(source));
+  } catch {
+    return null;
+  }
+  const found = findNodeAtOffset(ast, offset);
+  if (!found) return null;
+
+  const { node } = found;
+
+  // MotifRef → binding's span
+  if ((node as { kind: string }).kind === "MotifRef") {
+    const ref = node as { name: string };
+    const binding = findBinding(ast, ref.name);
+    if (binding) return spanToRange(source, binding.span);
+  }
+
+  // Call → binding's span (if it's a motif call, not effect)
+  if ((node as { kind: string }).kind === "Call") {
+    const call = node as { name: string };
+    const binding = findBinding(ast, call.name);
+    if (binding) return spanToRange(source, binding.span);
+  }
+
+  // InstrumentDirective name → InstrumentDef's span
+  if ((node as { kind: string }).kind === "Instrument") {
+    const directive = node as { name: string };
+    const inst = findInstrumentDef(ast, directive.name);
+    if (inst) return spanToRange(source, inst.span);
+  }
+
+  return null;
+}
+
+type BestNode = { node: object; kind: string; size: number };
+
+function findNodeAtOffset(ast: Composition, offset: number): { node: object; kind: string } | null {
+  let best: BestNode | null = null;
+  function visit(node: unknown): void {
+    if (!node || typeof node !== "object") return;
+    const obj = node as Record<string, unknown>;
+    const span = obj.span as SourceSpan | undefined;
+    if (span && typeof span.start === "number" && typeof span.end === "number") {
+      if (offset >= span.start && offset <= span.end) {
+        const size = span.end - span.start;
+        const currentBest: BestNode | null = best;
+        if (typeof obj.kind === "string" && (!currentBest || size <= currentBest.size)) {
+          best = { node: obj, kind: obj.kind, size };
+        }
+      }
+    }
+    for (const key of Object.keys(obj)) {
+      if (key === "span") continue;
+      const v = obj[key];
+      if (Array.isArray(v)) for (const item of v) visit(item);
+      else if (v && typeof v === "object") visit(v);
+    }
+  }
+  visit(ast);
+  if (!best) return null;
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+  const r = best as BestNode;
+  return { node: r.node, kind: r.kind };
+}
+
+function findBinding(ast: Composition, name: string): Binding | null {
+  function search(nodes: TopLevel[] | undefined): Binding | null {
+    if (!nodes) return null;
+    for (const n of nodes) {
+      if (n.kind === "Binding" && n.name === name) return n;
+      if (n.kind === "VoiceDecl") {
+        const r = search(n.body.body);
+        if (r) return r;
+      }
+    }
+    return null;
+  }
+  return search(ast.body);
+}
+
+function findInstrumentDef(ast: Composition, name: string): InstrumentDef | null {
+  function search(nodes: TopLevel[] | undefined): InstrumentDef | null {
+    if (!nodes) return null;
+    for (const n of nodes) {
+      if (n.kind === "InstrumentDef" && n.name === name) return n;
+      if (n.kind === "VoiceDecl") {
+        const r = search(n.body.body);
+        if (r) return r;
+      }
+    }
+    return null;
+  }
+  return search(ast.body);
+}

--- a/src/services/diagnostics.test.ts
+++ b/src/services/diagnostics.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { getDiagnostics } from "./diagnostics.js";
+
+describe("getDiagnostics", () => {
+  it("valid source -> no errors", () => {
+    expect(getDiagnostics("4 c4")).toEqual([]);
+  });
+
+  it("LexError -> one error diagnostic", () => {
+    const diags = getDiagnostics("4 c4 ! 4 d4");
+    expect(diags).toHaveLength(1);
+    expect(diags[0]?.severity).toBe("error");
+    expect(diags[0]?.source).toBe("synthjs");
+    expect(diags[0]?.message).toContain("unexpected character");
+  });
+
+  it("ParseError diagnostic has range", () => {
+    const diags = getDiagnostics("4 ,");
+    expect(diags).toHaveLength(1);
+    expect(diags[0]?.range).toBeDefined();
+    expect(diags[0]?.range.start.line).toBe(1);
+  });
+
+  it("ResolveError with suggestion preserves suggestion field", () => {
+    const diags = getDiagnostics("with reveerb(2, 1, 0.7) { 4 c4 }");
+    expect(diags).toHaveLength(1);
+    expect(diags[0]?.suggestion).toBe("reverb");
+  });
+
+  it("compileSync warnings (bar mismatch) yield warning severity", () => {
+    const src = "\\time 4/4\n4 c4 d e |";
+    const diags = getDiagnostics(src);
+    expect(diags.length).toBeGreaterThanOrEqual(1);
+    expect(diags.some((d) => d.severity === "warning")).toBe(true);
+  });
+
+  it("ValidationError with no \\key on scale-degree", () => {
+    const diags = getDiagnostics("4 ^1");
+    expect(diags).toHaveLength(1);
+    expect(diags[0]?.severity).toBe("error");
+  });
+
+  it("source field is always 'synthjs'", () => {
+    const diags = getDiagnostics("4 c4 ! 4 d4");
+    for (const d of diags) expect(d.source).toBe("synthjs");
+  });
+
+  it("diagnostic range has valid start and end positions", () => {
+    const diags = getDiagnostics("4 c4 ! 4 d4");
+    expect(diags[0]?.range.start).toHaveProperty("line");
+    expect(diags[0]?.range.start).toHaveProperty("column");
+    expect(diags[0]?.range.end).toHaveProperty("line");
+    expect(diags[0]?.range.end).toHaveProperty("column");
+  });
+
+  it("ParseError severity is error", () => {
+    const diags = getDiagnostics("4 ,");
+    expect(diags[0]?.severity).toBe("error");
+  });
+
+  it("valid multi-note source -> no diagnostics", () => {
+    expect(getDiagnostics("4 c4 d4 e4 f4")).toEqual([]);
+  });
+});

--- a/src/services/diagnostics.ts
+++ b/src/services/diagnostics.ts
@@ -1,0 +1,52 @@
+import { LexError, ParseError, ResolveError, ValidationError } from "../errors.js";
+import { compileSync } from "../semantic/pipeline.js";
+import { type Range, spanToRange } from "./position.js";
+
+export type DiagnosticSeverity = "error" | "warning" | "info";
+
+export type ServiceDiagnostic = {
+  range: Range;
+  severity: DiagnosticSeverity;
+  message: string;
+  source: "synthjs";
+  suggestion?: string;
+};
+
+export function getDiagnostics(source: string): ServiceDiagnostic[] {
+  const diags: ServiceDiagnostic[] = [];
+  try {
+    const ir = compileSync(source);
+    for (const d of ir.diagnostics) {
+      diags.push({
+        range: spanToRange(source, d.span),
+        severity: d.severity,
+        message: d.message,
+        source: "synthjs",
+      });
+    }
+  } catch (err) {
+    if (
+      err instanceof LexError ||
+      err instanceof ParseError ||
+      err instanceof ResolveError ||
+      err instanceof ValidationError
+    ) {
+      const base: ServiceDiagnostic = {
+        range: spanToRange(source, err.span),
+        severity: "error",
+        message: err.message,
+        source: "synthjs",
+      };
+      const suggestion = err instanceof ResolveError ? err.suggestion : undefined;
+      diags.push(suggestion !== undefined ? { ...base, suggestion } : base);
+    } else {
+      diags.push({
+        range: { start: { line: 1, column: 1 }, end: { line: 1, column: 1 } },
+        severity: "error",
+        message: (err as Error).message,
+        source: "synthjs",
+      });
+    }
+  }
+  return diags;
+}

--- a/src/services/hover.test.ts
+++ b/src/services/hover.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import { getHover } from "./hover.js";
+
+describe("getHover — pitches", () => {
+  it("absolute pitch shows frequency", () => {
+    const src = "4 c4";
+    // c4 starts at offset 2
+    const info = getHover(src, 2);
+    expect(info).not.toBeNull();
+    expect(info?.contents.join("\n")).toContain("c4");
+    expect(info?.contents.join("\n")).toMatch(/\d+\.\d+ Hz/);
+  });
+
+  it("pitch with cents shows detune", () => {
+    const src = "4 a4+15c";
+    const info = getHover(src, 2);
+    expect(info?.contents.join("\n")).toContain("Detune");
+    expect(info?.contents.join("\n")).toContain("15");
+  });
+
+  it("pitch without cents has no detune line", () => {
+    const src = "4 c4";
+    const info = getHover(src, 2);
+    expect(info?.contents.join("\n")).not.toContain("Detune");
+  });
+
+  it("hover returns a range with start/end", () => {
+    const src = "4 c4";
+    const info = getHover(src, 2);
+    expect(info?.range.start).toBeDefined();
+    expect(info?.range.end).toBeDefined();
+  });
+});
+
+describe("getHover — motif refs", () => {
+  it("resolves to binding", () => {
+    const src = "/// my intro\nintro = 4 c4\nintro";
+    // The trailing 'intro' is at offset around src.indexOf("intro", 25)
+    const offset = src.lastIndexOf("intro");
+    const info = getHover(src, offset);
+    expect(info).not.toBeNull();
+    expect(info?.contents.join("\n")).toContain("intro");
+    expect(info?.contents.join("\n")).toContain("my intro");
+  });
+
+  it("unresolved motif ref still produces hover", () => {
+    const src = "unknown";
+    const info = getHover(src, 0);
+    expect(info).not.toBeNull();
+    expect(info?.contents.join("\n")).toContain("unresolved");
+  });
+});
+
+describe("getHover — calls", () => {
+  it("call to known motif", () => {
+    const src = "/// arp doc\narp(root) = 8 root\narp(c4)";
+    const offset = src.lastIndexOf("arp");
+    const info = getHover(src, offset);
+    expect(info?.contents.join("\n")).toContain("arp(root)");
+  });
+
+  it("effect call shows signature", () => {
+    const src = "with reverb(2, 1, 0.7) { 4 c4 }";
+    const offset = src.indexOf("reverb");
+    const info = getHover(src, offset);
+    expect(info?.contents.join("\n")).toContain("reverb");
+    expect(info?.contents.join("\n")).toContain("channels");
+  });
+
+  it("unresolved call produces hover", () => {
+    const src = "/// fn\nfoo(x) = 4 x\nfoo(c4)";
+    const offset = src.lastIndexOf("foo");
+    const info = getHover(src, offset);
+    expect(info).not.toBeNull();
+  });
+});
+
+describe("getHover — annotations", () => {
+  it("known annotation shows signature", () => {
+    const src = '4 c4@cue("hit")';
+    const offset = src.indexOf("@cue");
+    const info = getHover(src, offset);
+    expect(info?.contents.join("\n")).toContain("@cue");
+  });
+
+  it("chance annotation shows signature", () => {
+    const src = "4 c4@chance(0.5)";
+    const offset = src.indexOf("@chance");
+    const info = getHover(src, offset);
+    expect(info?.contents.join("\n")).toContain("@chance");
+    expect(info?.contents.join("\n")).toContain("p");
+  });
+});
+
+describe("getHover — bindings", () => {
+  it("binding declaration shows signature + doc", () => {
+    const src = "/// docs\nintro = 4 c4";
+    const offset = src.indexOf("intro");
+    const info = getHover(src, offset);
+    expect(info?.contents.join("\n")).toContain("intro");
+  });
+
+  it("binding with params shows full signature", () => {
+    const src = "arp(root) = 4 root";
+    const offset = src.indexOf("arp");
+    const info = getHover(src, offset);
+    expect(info?.contents.join("\n")).toContain("arp(root)");
+  });
+});
+
+describe("getHover — instruments", () => {
+  it("instrument def shows name", () => {
+    const src = "instrument define warm { oscillator sawtooth }";
+    const offset = src.indexOf("warm");
+    const info = getHover(src, offset);
+    expect(info).not.toBeNull();
+    expect(info?.contents.join("\n")).toContain("warm");
+  });
+});
+
+describe("getHover — non-hoverable position", () => {
+  it("cursor on whitespace returns null or composition-level info", () => {
+    const src = "4 c4";
+    const info = getHover(src, 1); // space
+    // Either null or composition-level — both acceptable
+    if (info) {
+      expect(info.contents).toBeDefined();
+    }
+  });
+
+  it("malformed source returns null", () => {
+    const src = "4 ,";
+    expect(getHover(src, 0)).toBeNull();
+  });
+});

--- a/src/services/hover.ts
+++ b/src/services/hover.ts
@@ -1,0 +1,190 @@
+import type {
+  AbsolutePitch,
+  Annotation,
+  Binding,
+  CallExpr,
+  Composition,
+  InstrumentDef,
+  MotifRef,
+  TopLevel,
+} from "../ast/nodes.js";
+import type { SourceSpan } from "../errors.js";
+import { lex } from "../lexer/lexer.js";
+import { parse } from "../parser/parser.js";
+import { computeFrequency } from "../pitch.js";
+import { ANNOTATION_REGISTRY } from "../semantic/registries/annotations.js";
+import { EFFECT_REGISTRY } from "../semantic/registries/effects.js";
+import { type Range, spanToRange } from "./position.js";
+
+export type HoverInfo = {
+  range: Range;
+  contents: string[];
+};
+
+export function getHover(source: string, offset: number): HoverInfo | null {
+  let ast: Composition;
+  try {
+    ast = parse(lex(source));
+  } catch {
+    return null;
+  }
+
+  const found = findNodeAtOffset(ast, offset);
+  if (!found) return null;
+
+  const { node, kind } = found;
+
+  // Pitch hover
+  if (kind === "Pitch") {
+    const pitch = node as unknown as AbsolutePitch;
+    const freq = computeFrequency(pitch);
+    return {
+      range: spanToRange(source, pitch.span),
+      contents: [
+        `**Pitch:** ${pitch.letter}${pitch.accidental ?? ""}${pitch.octave ?? ""}`,
+        `**Frequency:** ${freq.toFixed(2)} Hz`,
+        ...(pitch.cents !== 0
+          ? [`**Detune:** ${pitch.cents > 0 ? "+" : ""}${pitch.cents} cents`]
+          : []),
+      ],
+    };
+  }
+
+  // MotifRef hover
+  if (kind === "MotifRef") {
+    const ref = node as unknown as MotifRef;
+    const binding = findBinding(ast, ref.name);
+    if (binding) {
+      const sig = binding.params ? `${binding.name}(${binding.params.join(", ")})` : binding.name;
+      const lines = [`**Motif:** \`${sig}\``];
+      if (binding.doc) lines.push(binding.doc.trim());
+      return { range: spanToRange(source, ref.span), contents: lines };
+    }
+    return {
+      range: spanToRange(source, ref.span),
+      contents: [`**Motif reference:** \`${ref.name}\` (unresolved)`],
+    };
+  }
+
+  // Call hover
+  if (kind === "Call") {
+    const call = node as unknown as CallExpr;
+    const binding = findBinding(ast, call.name);
+    if (binding) {
+      const sig = binding.params ? `${binding.name}(${binding.params.join(", ")})` : binding.name;
+      const lines = [`**Call:** \`${sig}\``];
+      if (binding.doc) lines.push(binding.doc.trim());
+      return { range: spanToRange(source, call.span), contents: lines };
+    }
+    // Effect call?
+    const effectSpec = EFFECT_REGISTRY[call.name];
+    if (effectSpec) {
+      const params = effectSpec.params.map((p) => `${p.name}: ${p.kind}`).join(", ");
+      return {
+        range: spanToRange(source, call.span),
+        contents: [`**Effect:** \`${call.name}(${params})\``],
+      };
+    }
+    return {
+      range: spanToRange(source, call.span),
+      contents: [`**Call:** \`${call.name}\` (unresolved)`],
+    };
+  }
+
+  // Annotation hover
+  if (kind === "Annotation") {
+    const anno = node as unknown as Annotation;
+    const spec = ANNOTATION_REGISTRY[anno.name];
+    if (spec) {
+      const params = spec.params.map((p) => `${p.name}: ${p.kind}`).join(", ");
+      return {
+        range: spanToRange(source, anno.span),
+        contents: [`**Annotation:** \`${anno.name}(${params})\``],
+      };
+    }
+    return {
+      range: spanToRange(source, anno.span),
+      contents: [`**Annotation:** \`${anno.name}\` (unknown)`],
+    };
+  }
+
+  // Binding declaration hover (cursor on a binding name)
+  if (kind === "Binding") {
+    const binding = node as unknown as Binding;
+    const sig = binding.params ? `${binding.name}(${binding.params.join(", ")})` : binding.name;
+    const lines = [`**Binding:** \`${sig}\``];
+    if (binding.doc) lines.push(binding.doc.trim());
+    return { range: spanToRange(source, binding.span), contents: lines };
+  }
+
+  // InstrumentDef hover
+  if (kind === "InstrumentDef") {
+    const def = node as unknown as InstrumentDef;
+    const lines = [`**Instrument:** \`${def.name}\``];
+    if (def.doc) lines.push(def.doc.trim());
+    return { range: spanToRange(source, def.span), contents: lines };
+  }
+
+  return null;
+}
+
+type FoundNode = {
+  node: Record<string, unknown> & { kind: string; span: SourceSpan };
+  kind: string;
+};
+
+function findNodeAtOffset(ast: Composition, offset: number): FoundNode | null {
+  // Walk tree, find smallest (deepest) node whose span contains offset.
+  // Uses half-open intervals: start <= offset < end.
+  // Equal-size nodes: prefer the later-visited (deeper/later sibling) one.
+  let best: FoundNode | null = null;
+
+  function visit(node: unknown): void {
+    if (!node || typeof node !== "object") return;
+    const obj = node as Record<string, unknown>;
+    const span = obj.span as SourceSpan | undefined;
+    if (span && typeof span.start === "number" && typeof span.end === "number") {
+      if (offset >= span.start && offset < span.end) {
+        const size = span.end - span.start;
+        const bestSize = best
+          ? best.node.span.end - best.node.span.start
+          : Number.POSITIVE_INFINITY;
+        if (size <= bestSize) {
+          if (typeof obj.kind === "string") {
+            best = {
+              node: obj as Record<string, unknown> & { kind: string; span: SourceSpan },
+              kind: obj.kind as string,
+            };
+          }
+        }
+      }
+    }
+    for (const key of Object.keys(obj)) {
+      if (key === "span") continue;
+      const v = obj[key];
+      if (Array.isArray(v)) {
+        for (const item of v) visit(item);
+      } else if (v && typeof v === "object") {
+        visit(v);
+      }
+    }
+  }
+
+  visit(ast);
+  return best;
+}
+
+function findBinding(ast: Composition, name: string): Binding | null {
+  function search(nodes: TopLevel[] | undefined): Binding | null {
+    if (!nodes) return null;
+    for (const n of nodes) {
+      if (n.kind === "Binding" && n.name === name) return n;
+      if (n.kind === "VoiceDecl") {
+        const r = search(n.body.body);
+        if (r) return r;
+      }
+    }
+    return null;
+  }
+  return search(ast.body);
+}

--- a/src/services/position.test.ts
+++ b/src/services/position.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import { offsetToPosition, positionToOffset, spanToRange } from "./position.js";
+
+describe("offsetToPosition", () => {
+  it("offset 0 -> line 1 col 1", () => {
+    expect(offsetToPosition("hello", 0)).toEqual({ line: 1, column: 1 });
+  });
+
+  it("mid-line offset", () => {
+    expect(offsetToPosition("hello world", 6)).toEqual({ line: 1, column: 7 });
+  });
+
+  it("offset past newline", () => {
+    expect(offsetToPosition("foo\nbar", 4)).toEqual({ line: 2, column: 1 });
+  });
+
+  it("offset on second line", () => {
+    expect(offsetToPosition("foo\nbar baz", 8)).toEqual({ line: 2, column: 5 });
+  });
+
+  it("offset beyond source clamps", () => {
+    expect(offsetToPosition("foo", 100)).toEqual({ line: 1, column: 4 });
+  });
+
+  it("negative offset clamps to start", () => {
+    expect(offsetToPosition("foo", -5)).toEqual({ line: 1, column: 1 });
+  });
+
+  it("empty string offset 0 -> line 1 col 1", () => {
+    expect(offsetToPosition("", 0)).toEqual({ line: 1, column: 1 });
+  });
+
+  it("offset at exact source length", () => {
+    expect(offsetToPosition("foo", 3)).toEqual({ line: 1, column: 4 });
+  });
+
+  it("multiple newlines", () => {
+    expect(offsetToPosition("a\nb\nc", 4)).toEqual({ line: 3, column: 1 });
+  });
+
+  it("offset at newline character itself", () => {
+    expect(offsetToPosition("foo\nbar", 3)).toEqual({ line: 1, column: 4 });
+  });
+
+  it("third line position", () => {
+    expect(offsetToPosition("ab\ncd\nef", 6)).toEqual({ line: 3, column: 1 });
+  });
+
+  it("consecutive newlines", () => {
+    expect(offsetToPosition("a\n\nb", 3)).toEqual({ line: 3, column: 1 });
+  });
+});
+
+describe("positionToOffset", () => {
+  it("line 1 col 1 -> 0", () => {
+    expect(positionToOffset("hello", { line: 1, column: 1 })).toBe(0);
+  });
+
+  it("mid-line position", () => {
+    expect(positionToOffset("hello world", { line: 1, column: 7 })).toBe(6);
+  });
+
+  it("position on second line", () => {
+    expect(positionToOffset("foo\nbar", { line: 2, column: 1 })).toBe(4);
+  });
+
+  it("roundtrip via offsetToPosition", () => {
+    const source = "abc\ndef\nghi";
+    for (let i = 0; i <= source.length; i++) {
+      const pos = offsetToPosition(source, i);
+      expect(positionToOffset(source, pos)).toBe(i);
+    }
+  });
+
+  it("position past end clamps to source.length", () => {
+    expect(positionToOffset("foo", { line: 99, column: 99 })).toBe(3);
+  });
+
+  it("empty string -> 0", () => {
+    expect(positionToOffset("", { line: 1, column: 1 })).toBe(0);
+  });
+
+  it("last character of line", () => {
+    expect(positionToOffset("foo\nbar", { line: 1, column: 3 })).toBe(2);
+  });
+});
+
+describe("spanToRange", () => {
+  it("uses span.line/column for start, computes end via offsetToPosition", () => {
+    const source = "hello world";
+    const range = spanToRange(source, { start: 0, end: 5, line: 1, column: 1 });
+    expect(range.start).toEqual({ line: 1, column: 1 });
+    expect(range.end).toEqual({ line: 1, column: 6 });
+  });
+
+  it("multi-line span", () => {
+    const source = "abc\ndef";
+    const range = spanToRange(source, { start: 0, end: 7, line: 1, column: 1 });
+    expect(range.end).toEqual({ line: 2, column: 4 });
+  });
+
+  it("span starting mid-line", () => {
+    const source = "hello world";
+    const range = spanToRange(source, { start: 6, end: 11, line: 1, column: 7 });
+    expect(range.start).toEqual({ line: 1, column: 7 });
+    expect(range.end).toEqual({ line: 1, column: 12 });
+  });
+
+  it("span start matches span.line and span.column directly", () => {
+    const source = "foo\nbar\nbaz";
+    const range = spanToRange(source, { start: 4, end: 7, line: 2, column: 1 });
+    expect(range.start).toEqual({ line: 2, column: 1 });
+  });
+});

--- a/src/services/position.ts
+++ b/src/services/position.ts
@@ -1,0 +1,41 @@
+import type { SourceSpan } from "../errors.js";
+
+export type Position = { line: number; column: number }; // 1-indexed
+export type Range = { start: Position; end: Position };
+
+export function offsetToPosition(source: string, offset: number): Position {
+  let line = 1;
+  let col = 1;
+  const upTo = Math.min(Math.max(0, offset), source.length);
+  for (let i = 0; i < upTo; i++) {
+    if (source[i] === "\n") {
+      line++;
+      col = 1;
+    } else {
+      col++;
+    }
+  }
+  return { line, column: col };
+}
+
+export function positionToOffset(source: string, pos: Position): number {
+  let line = 1;
+  let col = 1;
+  for (let i = 0; i < source.length; i++) {
+    if (line === pos.line && col === pos.column) return i;
+    if (source[i] === "\n") {
+      line++;
+      col = 1;
+    } else {
+      col++;
+    }
+  }
+  return source.length;
+}
+
+export function spanToRange(source: string, span: SourceSpan): Range {
+  return {
+    start: { line: span.line, column: span.column },
+    end: offsetToPosition(source, span.end),
+  };
+}

--- a/src/services/rename.test.ts
+++ b/src/services/rename.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { rename } from "./rename.js";
+
+describe("rename", () => {
+  it("renames a binding and all its references", () => {
+    const src = "intro = 4 c4\nintro\nintro";
+    const edits = rename(src, 0, "opening");
+    expect(edits).not.toBeNull();
+    expect(edits?.length).toBeGreaterThanOrEqual(3); // declaration + 2 refs
+    for (const edit of edits ?? []) {
+      expect(edit.newText).toBe("opening");
+    }
+  });
+
+  it("rename from a reference renames declaration too", () => {
+    const src = "intro = 4 c4\nintro";
+    const refOffset = src.lastIndexOf("intro");
+    const edits = rename(src, refOffset, "opening");
+    expect(edits).not.toBeNull();
+    expect(edits?.length).toBe(2);
+  });
+
+  it("renames parameterized motif", () => {
+    const src = "arp(root) = 8 root\narp(c4)\narp(g3)";
+    const edits = rename(src, 0, "arpeggio");
+    expect(edits).not.toBeNull();
+    expect(edits?.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("renames InstrumentDef and \\instrument references", () => {
+    const src = "instrument define warm { oscillator sawtooth }\n\\instrument warm\n4 c4";
+    const offset = src.indexOf("warm");
+    const edits = rename(src, offset, "cool");
+    expect(edits).not.toBeNull();
+    expect(edits?.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("invalid identifier returns null", () => {
+    const src = "intro = 4 c4";
+    expect(rename(src, 0, "bad name")).toBeNull();
+    expect(rename(src, 0, "1abc")).toBeNull();
+  });
+
+  it("cursor on non-renamable position returns null", () => {
+    const src = "4 c4";
+    expect(rename(src, 0, "x")).toBeNull();
+  });
+
+  it("malformed source returns null", () => {
+    expect(rename("4 ,", 0, "x")).toBeNull();
+  });
+
+  it("each edit has a range and newText", () => {
+    const src = "intro = 4 c4\nintro";
+    const edits = rename(src, 0, "opening");
+    for (const edit of edits ?? []) {
+      expect(edit.range.start).toBeDefined();
+      expect(edit.range.end).toBeDefined();
+      expect(typeof edit.newText).toBe("string");
+    }
+  });
+});

--- a/src/services/rename.ts
+++ b/src/services/rename.ts
@@ -1,0 +1,137 @@
+import type { Composition } from "../ast/nodes.js";
+import type { SourceSpan } from "../errors.js";
+import { lex } from "../lexer/lexer.js";
+import { parse } from "../parser/parser.js";
+import type { Range } from "./position.js";
+
+export type TextEdit = {
+  range: Range;
+  newText: string;
+};
+
+export function rename(source: string, offset: number, newName: string): TextEdit[] | null {
+  let ast: Composition;
+  try {
+    ast = parse(lex(source));
+  } catch {
+    return null;
+  }
+
+  const found = findNodeAtOffset(ast, offset);
+  if (!found) return null;
+
+  // Identify the symbol name
+  let oldName: string | undefined;
+  const node = found.node as { kind: string; name?: string };
+  if (
+    (node.kind === "Binding" ||
+      node.kind === "MotifRef" ||
+      node.kind === "Call" ||
+      node.kind === "InstrumentDef") &&
+    typeof node.name === "string"
+  ) {
+    oldName = node.name;
+  }
+
+  if (!oldName) return null;
+
+  if (!isValidIdentifier(newName)) return null;
+
+  const edits: TextEdit[] = [];
+  walkAst(ast, (n) => {
+    const obj = n as { kind: string; name?: string; span: SourceSpan };
+    if (
+      (obj.kind === "Binding" ||
+        obj.kind === "MotifRef" ||
+        obj.kind === "Call" ||
+        obj.kind === "InstrumentDef" ||
+        obj.kind === "Instrument") &&
+      obj.name === oldName
+    ) {
+      // For these node kinds, the span covers the full node (including args).
+      // We need to find the offset of `name` within the source for a precise edit.
+      // Heuristic: find oldName at obj.span.start.
+      const startPos = findNameOffsetInSpan(source, obj.span, oldName);
+      if (startPos !== null) {
+        const endPos = startPos + oldName.length;
+        edits.push({
+          range: {
+            start: positionFromOffset(source, startPos),
+            end: positionFromOffset(source, endPos),
+          },
+          newText: newName,
+        });
+      }
+    }
+  });
+
+  return edits;
+}
+
+function isValidIdentifier(s: string): boolean {
+  return /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(s);
+}
+
+type BestNode = { node: object; kind: string; size: number };
+
+function findNodeAtOffset(ast: Composition, offset: number): { node: object; kind: string } | null {
+  let best: BestNode | null = null;
+  function visit(node: unknown): void {
+    if (!node || typeof node !== "object") return;
+    const obj = node as Record<string, unknown>;
+    const span = obj.span as SourceSpan | undefined;
+    if (span && typeof span.start === "number" && typeof span.end === "number") {
+      if (offset >= span.start && offset <= span.end) {
+        const size = span.end - span.start;
+        const currentBest: BestNode | null = best;
+        if (typeof obj.kind === "string" && (!currentBest || size <= currentBest.size)) {
+          best = { node: obj, kind: obj.kind, size };
+        }
+      }
+    }
+    for (const key of Object.keys(obj)) {
+      if (key === "span") continue;
+      const v = obj[key];
+      if (Array.isArray(v)) for (const item of v) visit(item);
+      else if (v && typeof v === "object") visit(v);
+    }
+  }
+  visit(ast);
+  if (!best) return null;
+  const r = best as BestNode;
+  return { node: r.node, kind: r.kind };
+}
+
+function walkAst(ast: Composition, cb: (n: object) => void): void {
+  function visit(node: unknown): void {
+    if (!node || typeof node !== "object") return;
+    cb(node as object);
+    const obj = node as Record<string, unknown>;
+    for (const key of Object.keys(obj)) {
+      if (key === "span") continue;
+      const v = obj[key];
+      if (Array.isArray(v)) for (const item of v) visit(item);
+      else if (v && typeof v === "object") visit(v);
+    }
+  }
+  visit(ast);
+}
+
+function findNameOffsetInSpan(source: string, span: SourceSpan, name: string): number | null {
+  const slice = source.slice(span.start, span.end);
+  const idx = slice.indexOf(name);
+  if (idx === -1) return null;
+  return span.start + idx;
+}
+
+function positionFromOffset(source: string, offset: number) {
+  let line = 1;
+  let col = 1;
+  for (let i = 0; i < Math.min(offset, source.length); i++) {
+    if (source[i] === "\n") {
+      line++;
+      col = 1;
+    } else col++;
+  }
+  return { line, column: col };
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -16,4 +16,11 @@ export default defineConfig([
     sourcemap: true,
     banner: { js: "#!/usr/bin/env node" },
   },
+  {
+    entry: { lsp: "src/lsp/server.ts" },
+    format: ["esm"],
+    target: "es2022",
+    sourcemap: true,
+    banner: { js: "#!/usr/bin/env node" },
+  },
 ]);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,14 @@ export default defineConfig({
       provider: "v8",
       reporter: ["text", "html"],
       include: ["src/**/*.ts"],
-      exclude: ["src/**/*.test.ts", "src/index.ts", "src/ast/nodes.ts", "src/ir/nodes.ts", "src/cli/main.ts"],
+      exclude: [
+        "src/**/*.test.ts",
+        "src/index.ts",
+        "src/ast/nodes.ts",
+        "src/ir/nodes.ts",
+        "src/cli/main.ts",
+        "src/lsp/server.ts",
+      ],
       thresholds: {
         lines: 90,
         functions: 90,


### PR DESCRIPTION
## Summary

Phase 5b ships the editor-integration layer: pure-function language services + LSP server + CodeMirror-powered demo. Final remaining work before v2.0 stable.

## What ships

**Language services (`src/services/`)** — pure JS API:
- `getDiagnostics(source)` — diagnostics with range + suggestion
- `getHover(source, offset)` — pitch frequency, motif signature + doc, effect/annotation specs
- `getCompletions(source, offset)` — context-aware (`\`, `@`, `with `, `\instrument `, `\key `, default)
- `getDefinition(source, offset)` — jump to declaration
- `rename(source, offset, newName)` — list of TextEdits across all references
- Position helpers (`offsetToPosition`, `positionToOffset`, `spanToRange`)

**`synth-lsp` binary** — JSON-RPC over stdio. Implements initialize / textDocument lifecycle / hover / completion / definition / rename / prepareRename. Editors speaking LSP can connect.

**Demo upgrade (`demo/`)** — CodeMirror 6 editor with extensions calling each language service:
- 🔴 Inline error/warning highlights via lint gutter
- 🔍 Hover tooltips (rendered markdown for pitches, motifs, effects)
- ⌨️ Context-aware autocomplete
- 📄 Doc comments in hover + completion info
- CodeMirror loaded from esm.sh — no install step

## Stats

- 793 tests across 54 test files (was 704 at end of Phase 6)
- Coverage: 92.39% lines / 95.81% functions / 85.88% branches / 92.39% statements
- 9 commits on branch
- Tag: `v2.0.0-alpha.6`

## Test plan

- [x] typecheck 0
- [x] lint 0
- [x] tests 793/793
- [x] build emits dist/index.js + dist/cli.js + dist/lsp.js
- [x] coverage thresholds met
- [x] LSP integration tests via subprocess (initialize + publishDiagnostics + shutdown)

## Phase progress

- ✅ Phase 1 — lexer/parser/AST (191)
- ✅ Phase 2 — semantic/IR (448)
- ✅ Phase 3 — Web Audio runtime (558)
- ✅ Phase 4 — effect polish + lifecycle (602)
- ✅ Phase 5 — tooling (689)
- ✅ Phase 6 — stdlib + render CLI + demo (704)
- ✅ Phase 5b — language services + LSP + demo upgrade (this PR, 793)

**v2.0 alpha-stable.** Next milestone is promoting `v2.0.0-alpha.6` to `v2.0.0` once the public API freezes.

## Spec references

- Phase 5b plan: \`~/Code/personal/docs/2026-04-26-synthjs-v2-redesign-phase-5b-plan.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)