### PR TITLE
fix: prevent clicks/clipping in browser playback

### DIFF
--- a/src/runtime/composition.ts
+++ b/src/runtime/composition.ts
@@ -1,5 +1,5 @@
 import type { CompositionIR, Diagnostic, TimelineEvent } from "../ir/nodes.js";
-import type { AudioContextLike } from "./audio-context.js";
+import type { AudioContextLike, AudioNodeLike } from "./audio-context.js";
 import { LookaheadScheduler, type SchedulerOptions } from "./scheduler.js";
 import { beatsToSeconds } from "./time.js";
 import { VoicePlayer } from "./voice-player.js";
@@ -26,6 +26,7 @@ export class Composition {
   private readonly clearTimeoutFn: (handle: unknown) => void;
   private endedListeners: ((info: { totalDurationSec: number }) => void)[] = [];
   private playStartTime = 0;
+  private masterInput: AudioNodeLike | null = null;
 
   constructor(
     private readonly ir: CompositionIR,
@@ -44,10 +45,11 @@ export class Composition {
       this.ownsContext = true;
     }
     this.scheduler = new LookaheadScheduler(this.ctx, opts.scheduler);
-    this.setTimeoutFn =
-      opts.setTimeout ?? (globalThis.setTimeout as (cb: () => void, ms: number) => unknown);
-    this.clearTimeoutFn =
-      opts.clearTimeout ?? (globalThis.clearTimeout as (handle: unknown) => void);
+    // Wrap globalThis.setTimeout/clearTimeout in arrow functions so call site
+    // doesn't depend on `this` binding (browsers throw "Illegal invocation"
+    // when invoked as detached methods).
+    this.setTimeoutFn = opts.setTimeout ?? ((cb, ms) => globalThis.setTimeout(cb, ms));
+    this.clearTimeoutFn = opts.clearTimeout ?? ((h) => globalThis.clearTimeout(h as number));
   }
 
   private computeCompositionDuration(): number {
@@ -62,9 +64,31 @@ export class Composition {
     return max;
   }
 
+  /**
+   * Build a per-Composition master output chain: headroom gain → soft limiter →
+   * destination. Prevents inter-voice / inter-event clipping when many notes
+   * sum at once. Created lazily and reused across loop iterations.
+   *
+   *   voice → masterInput (headroom 0.7) → compressor → destination
+   */
+  private getMasterInput(): AudioNodeLike {
+    if (this.masterInput) return this.masterInput;
+    const headroom = this.ctx.createGain();
+    headroom.gain.value = 0.5;
+    const limiter = this.ctx.createDynamicsCompressor();
+    limiter.threshold.value = -6; // dB; engages well below 0 dBFS for smoother transients
+    limiter.ratio.value = 12;
+    limiter.attack.value = 0.003; // 3 ms — fast enough to catch peaks, slow enough to avoid pumping
+    limiter.release.value = 0.15;
+    headroom.connect(limiter);
+    limiter.connect(this.ctx.destination);
+    this.masterInput = headroom;
+    return headroom;
+  }
+
   private scheduleIteration(iterStartTime: number, fromBeat = 0): void {
     const voiceOutput = this.ctx.createGain();
-    voiceOutput.connect(this.ctx.destination);
+    voiceOutput.connect(this.getMasterInput());
     for (const voice of this.ir.voices) {
       const filteredVoice = {
         ...voice,

--- a/src/runtime/scheduler.ts
+++ b/src/runtime/scheduler.ts
@@ -26,9 +26,11 @@ export class LookaheadScheduler {
   ) {
     this.lookahead = opts.lookaheadSeconds ?? 0.025;
     this.interval = opts.intervalMs ?? 100;
-    this.setIntervalFn =
-      opts.setInterval ?? (globalThis.setInterval as (cb: () => void, ms: number) => unknown);
-    this.clearIntervalFn = opts.clearInterval ?? (globalThis.clearInterval as (h: unknown) => void);
+    // Wrap globalThis.setInterval/clearInterval in arrow functions so the call
+    // site doesn't depend on `this` binding (browsers throw "Illegal invocation"
+    // when these are invoked as detached methods).
+    this.setIntervalFn = opts.setInterval ?? ((cb, ms) => globalThis.setInterval(cb, ms));
+    this.clearIntervalFn = opts.clearInterval ?? ((h) => globalThis.clearInterval(h as number));
   }
 
   enqueue(event: ScheduledEvent): void {

--- a/src/runtime/voice-player.ts
+++ b/src/runtime/voice-player.ts
@@ -44,7 +44,12 @@ export class VoicePlayer {
       const audioStart = voiceStartTime + beatsToSeconds(event.startBeat, tempo);
       const baseSeconds = beatsToSeconds(event.durationBeats, tempo);
       const { playDuration, gainBoost } = applyArticulation(event.articulation, baseSeconds);
-      const peakGain = Math.min(1.0, event.gain * gainBoost);
+      // Equal-power normalization across chord pitches so an N-note chord
+      // doesn't sum to N× amplitude. 1-note event = no scaling. 4-note chord
+      // = 0.5× per pitch.
+      const pitchCount = Math.max(1, event.frequencies.length);
+      const polyScale = 1 / Math.sqrt(pitchCount);
+      const peakGain = Math.min(1.0, event.gain * gainBoost) * polyScale;
 
       // Schedule oscillators (one per frequency)
       const oscillators: OscillatorNodeLike[] = [];
@@ -74,13 +79,15 @@ export class VoicePlayer {
         event,
       });
 
-      // Schedule start/stop via scheduler
+      // Schedule start/stop via scheduler. Tail of 5 ms past play duration so
+      // the envelope's release ramp finishes before the oscillator hard-stops
+      // (prevents clicks at note boundaries).
       scheduler.enqueue({
         audioTime: audioStart,
         dispatch: (when) => {
           for (const osc of oscillators) {
             osc.start(when);
-            osc.stop(when + playDuration);
+            osc.stop(when + playDuration + 0.005);
           }
         },
       });


### PR DESCRIPTION
## Summary

Demo-page playback was throwing `TypeError: Illegal invocation` and producing audible clipping on chord-heavy examples. Three root causes, all fixed here.

## Fixes

### 1. Detached `this` on host timer methods

`LookaheadScheduler` and `Composition` stashed `globalThis.setInterval` / `setTimeout` (and their `clear*` counterparts) as fields. Browsers reject those when called without the global receiver:

```
TypeError: Illegal invocation
  at LookaheadScheduler.start (scheduler.ts:44)
  at Composition.play (composition.ts:120)
```

Wrap each in an arrow function so the call site is binding-agnostic:

```ts
this.setIntervalFn = opts.setInterval ?? ((cb, ms) => globalThis.setInterval(cb, ms));
```

### 2. Master output chain

Voices fed `ctx.destination` directly. Sum of multiple events / chord pitches routinely exceeded 0 dBFS, producing hard-clip crackle.

Inserted `voice → headroom (0.5) → DynamicsCompressorNode → destination`:

| Param | Value |
|------|------|
| threshold | −6 dB |
| ratio | 12:1 |
| attack | 3 ms |
| release | 150 ms |

The compressor is built lazily once per `Composition` and reused across loop iterations.

### 3. Equal-power chord normalization

Per-event peak gain now divided by `sqrt(pitchCount)`:

- 1-note: 1.0×
- 3-note triad: 0.577×
- 4-note voicing: 0.5×

Keeps dense polyphony bounded so the master limiter only catches transients, not steady state.

### 4. Oscillator stop tail

`osc.stop(when + playDuration + 0.005)` — gives the envelope's release ramp 5 ms to finish before the oscillator hard-stops. Eliminates per-note edge clicks.

## Test plan

- [x] `pnpm typecheck` 0
- [x] `pnpm lint` 0
- [x] `pnpm test` — 793/793 passing
- [x] `pnpm build` — emits dist/index.js + cli.js + lsp.js
- [x] Browser demo: scale, chords, two-voice, slide, dynamics — all clean
- [x] Browser demo: custom_instrument (warm_pad, 4-voice 1.2 s release) — clean
- [x] Browser demo: chord_progression (`@stdlib/chords` triads) — clean

## Files changed

- `src/runtime/scheduler.ts` — fix #1 (setInterval/clearInterval)
- `src/runtime/composition.ts` — fixes #1 (setTimeout/clearTimeout) + #2 (master chain)
- `src/runtime/voice-player.ts` — fixes #3 (polyScale) + #4 (stop tail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)