### PR TITLE
feat: pitch envelopes (pitch_sweep)

### DIFF
--- a/src/ast/nodes.ts
+++ b/src/ast/nodes.ts
@@ -77,7 +77,8 @@ export type InstrumentField =
   | { kind: "Oscillator"; value: string; detune?: number; span: SourceSpan }
   | { kind: "EnvelopeField"; call: Call; span: SourceSpan }
   | { kind: "FilterField"; call: Call; span: SourceSpan }
-  | { kind: "DetuneField"; cents: number; span: SourceSpan };
+  | { kind: "DetuneField"; cents: number; span: SourceSpan }
+  | { kind: "PitchSweepField"; semitones: number; duration: number; span: SourceSpan };
 
 // ----- Expressions -----
 

--- a/src/ir/emit.test.ts
+++ b/src/ir/emit.test.ts
@@ -207,6 +207,22 @@ describe("emit IR — instrument", () => {
     ]);
   });
 
+  it("pitch_sweep field captured in IR", () => {
+    const src =
+      "instrument define kick { oscillator sine pitch_sweep 12 0.05 envelope percussive(0.005, 0.4) }\n\\instrument kick\n4 c2";
+    const ir = compile(src);
+    const ev = ir.voices[0]?.events[0];
+    expect(ev?.instrument.pitchSweep).toEqual({ semitones: 12, duration: 0.05 });
+  });
+
+  it("pitch_sweep with negative semitones (rising sweep)", () => {
+    const src =
+      "instrument define rise { oscillator sawtooth pitch_sweep -7 0.1 }\n\\instrument rise\n4 c4";
+    const ir = compile(src);
+    const ev = ir.voices[0]?.events[0];
+    expect(ev?.instrument.pitchSweep).toEqual({ semitones: -7, duration: 0.1 });
+  });
+
   it("multi-filter instrument cascades in declared order", () => {
     const src =
       "instrument define chain { oscillator noise filter highpass(500, 0.7) filter bandpass(2000, 1.0) filter lowpass(8000, 0.7) }\n\\instrument chain\n4 c4";

--- a/src/ir/emit.ts
+++ b/src/ir/emit.ts
@@ -27,6 +27,7 @@ import type {
   InstrumentSpec,
   OscillatorKind,
   OscillatorLayer,
+  PitchSweep,
   TimelineEvent,
   VoiceTimeline,
 } from "./nodes.js";
@@ -131,6 +132,7 @@ function expandInstrumentDef(def: InstrumentDef): InstrumentSpec {
   let envelope: EnvelopeSpec | undefined;
   const filters: FilterSpec[] = [];
   let detune: number | undefined;
+  let pitchSweep: PitchSweep | undefined;
 
   for (const field of def.fields) {
     switch (field.kind) {
@@ -158,6 +160,9 @@ function expandInstrumentDef(def: InstrumentDef): InstrumentSpec {
       case "DetuneField":
         detune = field.cents;
         break;
+      case "PitchSweepField":
+        pitchSweep = { semitones: field.semitones, duration: field.duration };
+        break;
     }
   }
 
@@ -166,6 +171,7 @@ function expandInstrumentDef(def: InstrumentDef): InstrumentSpec {
   const spec: InstrumentSpec = { name: def.name, oscillators, filters };
   if (envelope !== undefined) spec.envelope = envelope;
   if (detune !== undefined) spec.detune = detune;
+  if (pitchSweep !== undefined) spec.pitchSweep = pitchSweep;
   return spec;
 }
 

--- a/src/ir/nodes.ts
+++ b/src/ir/nodes.ts
@@ -47,12 +47,22 @@ export type OscillatorLayer = {
 
 export type FilterSpec = { type: string; cutoff: number; q: number };
 
+export type PitchSweep = {
+  // Semitones offset above the note's nominal pitch at the start of the sweep.
+  // Positive = start sharp, sweep down to nominal (kick boom).
+  // Negative = start flat, sweep up to nominal (rising effect).
+  semitones: number;
+  // Duration of the sweep in seconds.
+  duration: number;
+};
+
 export type InstrumentSpec = {
   name: string; // primitive or custom name
   oscillators: OscillatorLayer[]; // length >= 1; single primitive = length-1 array
   envelope?: EnvelopeSpec; // from custom instrument body
   filters: FilterSpec[]; // length 0+; chained source -> f1 -> f2 -> ... -> output
   detune?: number; // instrument-level cents (applied to every layer)
+  pitchSweep?: PitchSweep; // optional pitch envelope; applies to all tonal layers
 };
 
 export type AnnotationData = {

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -522,6 +522,18 @@ class Parser {
       const cents = this.parseSignedNumber();
       return { kind: "DetuneField", cents, span: tok.span };
     }
+    if (val === "pitch_sweep") {
+      this.advance();
+      const semitones = this.parseSignedNumber();
+      const duration = this.parseNumber();
+      const endSpan = this.peekPrev().span;
+      return {
+        kind: "PitchSweepField",
+        semitones,
+        duration,
+        span: this.spanRange(tok.span, endSpan),
+      };
+    }
     throw new ParseError(`unknown instrument field '${val}'`, tok.span);
   }
 

--- a/src/runtime/voice-player.test.ts
+++ b/src/runtime/voice-player.test.ts
@@ -111,6 +111,74 @@ describe("VoicePlayer — slide", () => {
   });
 });
 
+describe("VoicePlayer — pitch sweep", () => {
+  it("schedules exponential ramp from offset pitch to nominal", () => {
+    const kickInstrument: InstrumentSpec = {
+      name: "kick",
+      oscillators: [{ kind: "sine" }],
+      filters: [],
+      pitchSweep: { semitones: 12, duration: 0.05 },
+    };
+    const ev = noteEvent({
+      frequencies: [110],
+      durationBeats: 0.5,
+      instrument: kickInstrument,
+    });
+    const { ctx, scheduler, player } = setup([ev]);
+    player.schedule();
+    scheduler.flush(100);
+    const oscRec = ctx.history.find((h) => h.method === "createOscillator");
+    const freqHist = (
+      (oscRec?.result as { frequency: unknown }).frequency as unknown as { history: unknown[] }
+    ).history;
+    // Start at 220 Hz (110 * 2^(12/12) = octave up), ramp to 110 Hz at start + 0.05s
+    expect(freqHist).toContainEqual({
+      method: "param",
+      name: "frequency",
+      op: "setValueAtTime",
+      value: 220,
+      time: 0,
+    });
+    expect(freqHist).toContainEqual({
+      method: "param",
+      name: "frequency",
+      op: "exponentialRampToValueAtTime",
+      value: 110,
+      time: 0.05,
+    });
+  });
+
+  it("slide takes precedence over pitch_sweep", () => {
+    const inst: InstrumentSpec = {
+      name: "rise",
+      oscillators: [{ kind: "sine" }],
+      filters: [],
+      pitchSweep: { semitones: 12, duration: 0.05 },
+    };
+    const ev = noteEvent({
+      frequencies: [220],
+      slideTo: [440],
+      durationBeats: 0.5,
+      instrument: inst,
+    });
+    const { ctx, scheduler, player } = setup([ev]);
+    player.schedule();
+    scheduler.flush(100);
+    const oscRec = ctx.history.find((h) => h.method === "createOscillator");
+    const freqHist = (
+      (oscRec?.result as { frequency: unknown }).frequency as unknown as { history: unknown[] }
+    ).history;
+    // Slide writes setValueAtTime(220, 0) + linearRampToValueAtTime(440, ...);
+    // pitch_sweep would have written exponentialRampToValueAtTime — must not be present.
+    expect(freqHist).not.toContainEqual(
+      expect.objectContaining({ op: "exponentialRampToValueAtTime" }),
+    );
+    expect(freqHist).toContainEqual(
+      expect.objectContaining({ op: "linearRampToValueAtTime", value: 440 }),
+    );
+  });
+});
+
 describe("VoicePlayer — annotations", () => {
   it("@chance(0) skips the event", () => {
     const ev = noteEvent({

--- a/src/runtime/voice-player.ts
+++ b/src/runtime/voice-player.ts
@@ -98,6 +98,16 @@ export class VoicePlayer {
           for (const freqParam of oscRig.frequencies) {
             applySlide(freqParam, freq, slideTarget, audioStart, playDuration);
           }
+        } else if (event.instrument.pitchSweep !== undefined) {
+          // Pitch envelope: exponential sweep from start offset to nominal
+          // pitch over `duration` seconds, on every tonal layer.
+          const sweep = event.instrument.pitchSweep;
+          const startFreq = freq * 2 ** (sweep.semitones / 12);
+          const sweepEnd = Math.min(playDuration, sweep.duration);
+          for (const freqParam of oscRig.frequencies) {
+            freqParam.setValueAtTime(startFreq, audioStart);
+            freqParam.exponentialRampToValueAtTime(freq, audioStart + sweepEnd);
+          }
         }
         oscillators.push(oscRig.source);
       }

--- a/src/semantic/resolve.ts
+++ b/src/semantic/resolve.ts
@@ -320,6 +320,14 @@ function validateInstrumentDef(def: InstrumentDef): void {
       case "DetuneField":
         // No validation needed
         break;
+      case "PitchSweepField":
+        if (field.duration < 0) {
+          throw new ResolveError(
+            `pitch_sweep duration must be non-negative, got ${field.duration}`,
+            field.span,
+          );
+        }
+        break;
     }
   }
 }

--- a/src/stdlib/drums.ts
+++ b/src/stdlib/drums.ts
@@ -1,9 +1,10 @@
 export const DRUMS_SOURCE = `\\version "2.0"
 
-/// Kick drum — low sine, fast attack, fast decay
+/// Kick drum — low sine with fast pitch drop for the boom
 instrument define kick_drum {
   oscillator sine
-  envelope percussive(0.001, 0.15)
+  envelope percussive(0.001, 0.18)
+  pitch_sweep 24 0.05
   detune -1200
 }
 
@@ -30,53 +31,55 @@ instrument define hat_open {
 
 /// ============================================================
 /// 808-style kit — vintage Roland TR-808 character via stacks
-/// + filter cascades. Drop-in replacements for the noise/sine
-/// variants above. The original 808 used pitch-envelope sweeps
-/// for kick and toms which this DSL does not yet support, so
-/// those pieces are static-pitch approximations.
+/// + filter cascades + pitch sweeps. Drop-in replacements for
+/// the noise/sine variants above.
 /// ============================================================
 
-/// 808-style bass drum — sine body + sub layer, lowpassed.
-/// Play at a low pitch (c2, a1) and let the percussive envelope
-/// shape the boom. Lacks the iconic 808 pitch sweep.
+/// 808-style bass drum — sine body + sub layer, lowpassed,
+/// with fast 2-octave pitch drop for the iconic 808 boom.
 instrument define bass_drum_808 {
   oscillator sine
   oscillator sine -7
-  envelope percussive(0.002, 0.45)
-  filter lowpass(120, 1.0)
+  envelope percussive(0.002, 0.5)
+  pitch_sweep 24 0.06
+  filter lowpass(150, 1.0)
   detune -1200
 }
 
 /// 808-style snare — two detuned triangles for tonal body
 /// stacked with noise for the wire rattle. Bandpass focuses the
-/// snap. Play at c4/d4.
+/// snap. Pitch drop on the tonal layers makes the body smack.
 instrument define snare_drum_808 {
   oscillator triangle -1200
   oscillator triangle -1500
   oscillator noise
   envelope percussive(0.001, 0.15)
+  pitch_sweep 7 0.03
   filter highpass(800, 0.7)
   filter bandpass(2000, 1.5)
 }
 
-/// 808-style low tom — sine, deep
+/// 808-style low tom — sine with octave pitch drop
 instrument define tom_low_808 {
   oscillator sine -800
-  envelope percussive(0.005, 0.45)
+  envelope percussive(0.005, 0.5)
+  pitch_sweep 12 0.08
   filter lowpass(800, 1.0)
 }
 
-/// 808-style mid tom — sine, mid
+/// 808-style mid tom — sine with octave pitch drop
 instrument define tom_mid_808 {
   oscillator sine -400
-  envelope percussive(0.005, 0.4)
+  envelope percussive(0.005, 0.45)
+  pitch_sweep 12 0.07
   filter lowpass(1000, 1.0)
 }
 
-/// 808-style high tom — sine, high
+/// 808-style high tom — sine with octave pitch drop
 instrument define tom_high_808 {
   oscillator sine -100
-  envelope percussive(0.005, 0.35)
+  envelope percussive(0.005, 0.4)
+  pitch_sweep 12 0.06
   filter lowpass(1200, 1.0)
 }
 

--- a/src/tools/format.ts
+++ b/src/tools/format.ts
@@ -286,6 +286,8 @@ function printInstrumentField(f: InstrumentField, depth: number): string {
       return `${indent(depth)}filter ${printCall(f.call)}`;
     case "DetuneField":
       return `${indent(depth)}detune ${formatNumber(f.cents)}`;
+    case "PitchSweepField":
+      return `${indent(depth)}pitch_sweep ${formatNumber(f.semitones)} ${formatNumber(f.duration)}`;
   }
 }
 


### PR DESCRIPTION
## Summary
- New instrument field `pitch_sweep <semitones> <duration>` schedules an exponential frequency ramp from `note × 2^(semitones/12)` down (or up, if negative) to the nominal note pitch over `duration` seconds.
- Applies to every tonal layer in lockstep so detune offsets in oscillator stacks are preserved.
- Slide on the same event takes precedence over pitch_sweep.

## DSL example

```
instrument define bass_drum_808 {
  oscillator sine
  oscillator sine -7
  envelope percussive(0.002, 0.5)
  pitch_sweep 24 0.06
  filter lowpass(150, 1.0)
  detune -1200
}
```

The kick now starts two octaves above the played pitch and exponentially drops to it over 60ms — the canonical 808 boom.

## Stdlib retuned
- `kick_drum`: 24 semitones / 50ms drop
- `bass_drum_808`: 24 semitones / 60ms drop
- `snare_drum_808`: 7 semitones / 30ms body smack
- `tom_low/mid/high_808`: 12 semitones / 60–80ms

## Test plan
- [x] `pnpm test` (806 tests, +4 new)
- [x] `pnpm lint`
- [x] `pnpm build`
- [ ] Demo: kick should sound noticeably bigger / less static
- [ ] Confirm slide-bearing notes are unaffected when pitch_sweep is also set

🤖 Generated with [Claude Code](https://claude.com/claude-code)