### PR TITLE
feat(demo): live mode — loop + mute/solo + AI suggest-a-part (PR 23 of 5)

### DIFF
--- a/demo/app-shell.js
+++ b/demo/app-shell.js
@@ -256,7 +256,11 @@ export function mountAppShell({ root }) {
         onSourceChange: (source) => scheduleSave(source),
       });
     } else if (activeMode === "live") {
-      mounted = mountLiveMode({ parent: workspaceEl, project: activeProject });
+      mounted = mountLiveMode({
+        parent: workspaceEl,
+        project: activeProject,
+        onSourceChange: (source) => scheduleSave(source),
+      });
     } else if (activeMode === "review") {
       mounted = mountReviewMode({ parent: workspaceEl, project: activeProject });
     }

--- a/demo/app-shell.js
+++ b/demo/app-shell.js
@@ -39,16 +39,49 @@ const SAVE_PULSE_MS = 700;
 const SEED_SOURCE = `\\version "2.0"
 \\use "@stdlib/instruments"
 \\use "@stdlib/drums"
+\\key c#4 phrygian
 \\tempo 100
 \\time 4/4
 
 voice melody {
-  \\instrument bell
+  \\instrument melody_instrument
   \\mp
-  with reverb(2, 1.6, 0.5) {
-    4 c5 d e f
-    4 g a b c6
+  8 ^1
+  4 ^3 ^4
+  8 ^3 ^4
+  4 ^5
+  8 ^7 ^5 ^4 ^2 ^1 ^2
+}
+
+voice drums {
+  \\instrument hat_closed_808
+  \\p
+  repeat 2 {
+    8 r f6 r f r f r f
   }
+}
+
+voice kick {
+  \\instrument kick_drum
+  \\f
+  repeat 2 {
+    4 c2 c c c
+  }
+}
+
+voice snare {
+  \\instrument snare_drum
+  \\mf
+  repeat 2 {
+    4 r d3 r d
+  }
+}
+
+instrument define melody_instrument {
+  oscillator sawtooth
+  envelope adsr(0.14, 0.2, 0.75, 0.5)
+  filter lowpass(3500, 0.6)
+  gain 0.85
 }
 `;
 

--- a/demo/live-mode.js
+++ b/demo/live-mode.js
@@ -27,7 +27,6 @@ import {
   compileSync,
   extractAllDslBlocks,
   isTruncated,
-  isolateIR,
   mergeBlocks,
 } from "synth-javascript";
 
@@ -138,23 +137,33 @@ export function mountLiveMode({ parent, project, onSourceChange }) {
       else soloVoices.add(name);
     }
     renderVoices();
-    if (composition) hotReload();
+    applyMuteSolo();
   });
 
+  /**
+   * Apply the current mute + solo state to the running composition by
+   * flipping per-voice gain gates — sample-accurate, no rescheduling.
+   * Also works before any composition is playing: the gates are created
+   * lazily, so toggling now persists into the next play().
+   */
+  function applyMuteSolo() {
+    if (!composition) return;
+    if (soloVoices.size > 0) {
+      composition.setSolo(soloVoices);
+    } else {
+      composition.setSolo(new Set()); // clear any prior solo
+      for (const v of currentIR.voices) {
+        composition.setVoiceMuted(v.name, mutedVoices.has(v.name));
+      }
+    }
+  }
+
   // ---- Transport ----
-  function activeVoiceNames() {
-    if (soloVoices.size > 0) return [...soloVoices];
-    return currentIR.voices.map((v) => v.name).filter((n) => !mutedVoices.has(n));
-  }
-
-  function buildLiveIR() {
-    return isolateIR(currentIR, { voices: activeVoiceNames() });
-  }
-
   async function startLoop() {
     if (composition) return;
-    const ir = buildLiveIR();
-    composition = new Composition(ir);
+    composition = new Composition(currentIR);
+    // Re-apply any mute/solo state set before play started.
+    applyMuteSolo();
     isLooping = true;
     transportPlayBtn.classList.add("is-on");
     setAiStatus("loop running — ask the assistant for a part");
@@ -177,10 +186,16 @@ export function mountLiveMode({ parent, project, onSourceChange }) {
     clearBeatLEDs();
   }
 
-  async function hotReload() {
+  /**
+   * Used when the IR itself changes (AI-accepted proposal). Mute/solo
+   * doesn't go through here — the per-voice gain gates handle those
+   * without touching the schedule.
+   */
+  async function hotReloadIR() {
     if (!composition) return;
     try {
-      await composition.update(buildLiveIR());
+      await composition.update(currentIR);
+      applyMuteSolo();
     } catch (err) {
       console.warn("live: hot-reload failed", err);
     }
@@ -341,7 +356,7 @@ export function mountLiveMode({ parent, project, onSourceChange }) {
     clearProposal();
     aiStreamEl.hidden = true;
     setAiStatus(isLooping ? "applied · running" : "applied · press play to hear it");
-    if (composition) await hotReload();
+    if (composition) await hotReloadIR();
   });
 
   aiRejectBtn.addEventListener("click", () => {

--- a/demo/live-mode.js
+++ b/demo/live-mode.js
@@ -1,39 +1,437 @@
 /**
- * Live mode — placeholder. The full build (loop transport + per-voice
- * mute/solo grid + AI "suggest a part" hot-reload) lands in PR 23.
+ * Live mode — performance + AI co-creation.
  *
- * The placeholder still feels deliberate: hardware-style sequencer pads
- * laid out in a grid, dimmed to indicate "not yet wired", with a single
- * pulsing yellow LED as a hint that something is alive.
+ * Layout:
+ *   ┌─────────────────────────────────────────────┐
+ *   │ TRANSPORT (loop play/stop · BPM · bar/beat) │
+ *   ├─────────────────────────────────────────────┤
+ *   │ VOICE GRID (per-voice pad: mute · solo)     │
+ *   │ — beat-synced LED pulses on each card —     │
+ *   ├─────────────────────────────────────────────┤
+ *   │ AI SUGGEST PANEL                            │
+ *   │ — "drop a clap on every backbeat" → diff →  │
+ *   │ accept hot-reloads the running composition  │
+ *   └─────────────────────────────────────────────┘
+ *
+ * Built on existing Composition + isolateIR + AI provider stack. Mute/solo
+ * toggles rebuild the IR via isolateIR and call Composition.update() so
+ * voices drop in/out without restarting the loop.
  */
 
-export function mountLiveMode({ parent, project }) {
-  parent.innerHTML = `
-    <div class="placeholder-mode live-placeholder">
+import {
+  Composition,
+  GroqProvider,
+  WebLLMProvider,
+  buildSystemPrompt,
+  buildUserMessage,
+  compileSync,
+  extractAllDslBlocks,
+  isTruncated,
+  isolateIR,
+  mergeBlocks,
+} from "synth-javascript";
+
+const GROQ_KEY_STORAGE = "synthjs.ai.groqKey";
+
+export function mountLiveMode({ parent, project, onSourceChange }) {
+  // Compile once on mount; bail early on broken sources with a friendly
+  // panel so the user can switch back to compose mode and fix.
+  let baselineIR;
+  try {
+    baselineIR = compileSync(project.source);
+  } catch (err) {
+    parent.innerHTML = `
+      <div class="live-shell live-error">
+        <div class="panel-head">
+          <span class="panel-num">LIVE</span>
+          <h2 class="panel-title">composition won't compile</h2>
+        </div>
+        <pre class="review-error">${escapeHtml(err?.message ?? String(err))}</pre>
+        <p class="placeholder-blurb">Switch to compose mode and fix the diagnostics; live mode needs a clean IR to perform.</p>
+      </div>
+    `;
+    return { destroy: () => {} };
+  }
+
+  const initialVoices = baselineIR.voices.map((v) => v.name);
+  parent.innerHTML = renderShell(initialVoices);
+
+  // ---- DOM refs ----
+  const transportPlayBtn = parent.querySelector("#live-play");
+  const transportStopBtn = parent.querySelector("#live-stop");
+  const tempoLabel = parent.querySelector("#live-tempo");
+  const beatLabel = parent.querySelector("#live-beat");
+  const voiceGridEl = parent.querySelector("#live-voices");
+  const aiInput = parent.querySelector("#live-ai-input");
+  const aiSendBtn = parent.querySelector("#live-ai-send");
+  const aiCancelBtn = parent.querySelector("#live-ai-cancel");
+  const aiStatusEl = parent.querySelector("#live-ai-status");
+  const aiStreamEl = parent.querySelector("#live-ai-stream");
+  const aiResultEl = parent.querySelector("#live-ai-result");
+  const aiAcceptBtn = parent.querySelector("#live-ai-accept");
+  const aiRejectBtn = parent.querySelector("#live-ai-reject");
+  const providerLabel = parent.querySelector("#live-ai-provider");
+
+  // ---- State ----
+  let composition = null;
+  let isLooping = false;
+  let beatTickHandle = 0;
+  let mutedVoices = new Set();
+  let soloVoices = new Set();
+  let currentSource = project.source;
+  let currentIR = baselineIR;
+  let pendingProposal = null; // { proposed, summary }
+  let aiAbort = null;
+
+  // Provider — same selection logic as compose mode (read the saved Groq
+  // key, prefer Groq when present, fall back to WebLLM).
+  let provider = new WebLLMProvider();
+  try {
+    const key = localStorage.getItem(GROQ_KEY_STORAGE);
+    if (key) {
+      provider = new GroqProvider({ apiKey: key });
+      providerLabel.textContent = "groq · llama 3.3 70b";
+    } else {
+      providerLabel.textContent = "webllm · llama 3.2 3b";
+    }
+  } catch {}
+
+  // ---- Voice grid ----
+  function renderVoices() {
+    voiceGridEl.innerHTML = currentIR.voices
+      .map((v) => {
+        const muted = mutedVoices.has(v.name);
+        const solo = soloVoices.has(v.name);
+        const eventCount = v.events.length;
+        return `
+          <div class="voice-card ${muted ? "is-muted" : ""} ${solo ? "is-solo" : ""}" data-voice="${escapeHtml(v.name)}">
+            <div class="voice-card-head">
+              <span class="voice-card-led" aria-hidden="true"></span>
+              <span class="voice-card-name">${escapeHtml(v.name)}</span>
+              <span class="voice-card-meta">${eventCount} ev</span>
+            </div>
+            <div class="voice-card-buttons">
+              <button class="pad-btn ${muted ? "is-on" : ""}" data-action="mute" title="Mute this voice">
+                M
+              </button>
+              <button class="pad-btn pad-btn-solo ${solo ? "is-on" : ""}" data-action="solo" title="Solo this voice">
+                S
+              </button>
+            </div>
+          </div>
+        `;
+      })
+      .join("");
+  }
+
+  voiceGridEl.addEventListener("click", (ev) => {
+    const btn = ev.target.closest("[data-action]");
+    if (!btn) return;
+    const card = btn.closest(".voice-card");
+    if (!card) return;
+    const name = card.dataset.voice;
+    if (btn.dataset.action === "mute") {
+      if (mutedVoices.has(name)) mutedVoices.delete(name);
+      else mutedVoices.add(name);
+    } else if (btn.dataset.action === "solo") {
+      if (soloVoices.has(name)) soloVoices.delete(name);
+      else soloVoices.add(name);
+    }
+    renderVoices();
+    if (composition) hotReload();
+  });
+
+  // ---- Transport ----
+  function activeVoiceNames() {
+    if (soloVoices.size > 0) return [...soloVoices];
+    return currentIR.voices.map((v) => v.name).filter((n) => !mutedVoices.has(n));
+  }
+
+  function buildLiveIR() {
+    return isolateIR(currentIR, { voices: activeVoiceNames() });
+  }
+
+  async function startLoop() {
+    if (composition) return;
+    const ir = buildLiveIR();
+    composition = new Composition(ir);
+    isLooping = true;
+    transportPlayBtn.classList.add("is-on");
+    setAiStatus("loop running — ask the assistant for a part");
+    await composition.play({ loop: true });
+    startBeatTicker();
+  }
+
+  async function stopLoop() {
+    isLooping = false;
+    transportPlayBtn.classList.remove("is-on");
+    stopBeatTicker();
+    if (composition) {
+      composition.stop();
+      try {
+        await composition.destroy();
+      } catch {}
+      composition = null;
+    }
+    beatLabel.textContent = "—";
+    clearBeatLEDs();
+  }
+
+  async function hotReload() {
+    if (!composition) return;
+    try {
+      await composition.update(buildLiveIR());
+    } catch (err) {
+      console.warn("live: hot-reload failed", err);
+    }
+  }
+
+  transportPlayBtn.addEventListener("click", () => {
+    if (isLooping) stopLoop();
+    else startLoop();
+  });
+  transportStopBtn.addEventListener("click", () => stopLoop());
+
+  // ---- Beat ticker — drives the LED pulse on each voice card ----
+  function startBeatTicker() {
+    stopBeatTicker();
+    const startedAt = performance.now();
+    const tempo = currentIR.tempo;
+    const tsNum = currentIR.timeSig?.numerator ?? 4;
+    const tsDen = currentIR.timeSig?.denominator ?? 4;
+    const beatMs = (60_000 / tempo) | 0;
+    beatTickHandle = setInterval(() => {
+      const elapsedMs = performance.now() - startedAt;
+      const beatIdx = Math.floor(elapsedMs / beatMs);
+      const beatInBar = (beatIdx % tsNum) + 1;
+      const barIdx = Math.floor(beatIdx / tsNum) + 1;
+      beatLabel.textContent = `${barIdx.toString().padStart(2, "0")}.${beatInBar}`;
+      // Flash every voice-card LED on the downbeat for a satisfying pulse;
+      // dim them briefly so they read as a series of pulses.
+      const isDownbeat = beatIdx % tsNum === 0;
+      for (const card of voiceGridEl.querySelectorAll(".voice-card")) {
+        card.classList.toggle("is-pulse-strong", isDownbeat);
+        card.classList.add("is-pulsing");
+        setTimeout(() => card.classList.remove("is-pulsing"), beatMs / 2);
+      }
+    }, beatMs);
+  }
+
+  function stopBeatTicker() {
+    if (beatTickHandle) clearInterval(beatTickHandle);
+    beatTickHandle = 0;
+  }
+
+  function clearBeatLEDs() {
+    for (const card of voiceGridEl.querySelectorAll(".voice-card")) {
+      card.classList.remove("is-pulsing", "is-pulse-strong");
+    }
+  }
+
+  // ---- AI suggest-a-part ----
+  function setAiStatus(text) {
+    aiStatusEl.textContent = text;
+  }
+
+  function clearProposal() {
+    pendingProposal = null;
+    aiResultEl.hidden = true;
+    aiAcceptBtn.hidden = true;
+    aiRejectBtn.hidden = true;
+  }
+
+  aiSendBtn.addEventListener("click", async () => {
+    const instruction = aiInput.value.trim();
+    if (!instruction) return;
+    clearProposal();
+    aiStreamEl.textContent = "";
+    aiStreamEl.hidden = false;
+    aiSendBtn.hidden = true;
+    aiCancelBtn.hidden = false;
+    setAiStatus("generating part…");
+    aiAbort = new AbortController();
+
+    const messages = [
+      { role: "system", content: buildSystemPrompt() },
+      {
+        role: "user",
+        content: buildUserMessage({
+          currentSource,
+          instruction:
+            "Live performance — keep the existing tempo, time signature, and other voices. " +
+            "If the request describes adding/altering a SINGLE voice or instrument, emit just that one block. " +
+            "Otherwise emit the minimum set of blocks. " +
+            instruction,
+        }),
+      },
+    ];
+
+    let collected = "";
+    try {
+      if (!provider.isReady()) {
+        setAiStatus("loading model…");
+        for await (const msg of provider.prepare?.({ signal: aiAbort.signal }) ?? []) {
+          setAiStatus(msg);
+        }
+      }
+      for await (const chunk of provider.chat(messages, {
+        signal: aiAbort.signal,
+        maxTokens: 4096,
+        temperature: 0.7,
+      })) {
+        collected += chunk;
+        aiStreamEl.textContent = collected;
+        aiStreamEl.scrollTop = aiStreamEl.scrollHeight;
+      }
+    } catch (err) {
+      if (err?.name === "AbortError") setAiStatus("cancelled");
+      else setAiStatus(`error: ${err?.message ?? err}`);
+      aiSendBtn.hidden = false;
+      aiCancelBtn.hidden = true;
+      return;
+    }
+    aiSendBtn.hidden = false;
+    aiCancelBtn.hidden = true;
+    aiAbort = null;
+
+    const blocks = extractAllDslBlocks(collected);
+    if (blocks.length === 0) {
+      setAiStatus("model returned no fenced ```synth block");
+      return;
+    }
+    let merged = currentSource;
+    const replaced = [];
+    const added = [];
+    for (const b of blocks) {
+      const m = mergeBlocks(merged, b);
+      merged = m.text;
+      replaced.push(...m.replaced);
+      added.push(...m.added);
+    }
+    let proposedIR;
+    try {
+      proposedIR = compileSync(merged);
+    } catch (err) {
+      setAiStatus(`proposal does not compile: ${err?.message ?? err}`);
+      return;
+    }
+    pendingProposal = { proposed: merged, ir: proposedIR };
+    aiResultEl.hidden = false;
+    aiResultEl.innerHTML = `
+      <div class="live-ai-summary">
+        ${replaced.length ? `<span class="live-ai-tag live-ai-tag-replaced">replaced ${replaced.join(", ")}</span>` : ""}
+        ${added.length ? `<span class="live-ai-tag live-ai-tag-added">added ${added.join(", ")}</span>` : ""}
+        ${truncatedNote(collected)}
+      </div>
+    `;
+    aiAcceptBtn.hidden = false;
+    aiRejectBtn.hidden = false;
+    setAiStatus("proposal ready · accept hot-reloads it into the running loop");
+  });
+
+  aiCancelBtn.addEventListener("click", () => aiAbort?.abort());
+
+  aiAcceptBtn.addEventListener("click", async () => {
+    if (!pendingProposal) return;
+    currentSource = pendingProposal.proposed;
+    currentIR = pendingProposal.ir;
+    onSourceChange?.(currentSource);
+    renderVoices();
+    aiInput.value = "";
+    clearProposal();
+    aiStreamEl.hidden = true;
+    setAiStatus(isLooping ? "applied · running" : "applied · press play to hear it");
+    if (composition) await hotReload();
+  });
+
+  aiRejectBtn.addEventListener("click", () => {
+    clearProposal();
+    aiStreamEl.hidden = true;
+    setAiStatus("rejected");
+  });
+
+  // ---- Boot ----
+  tempoLabel.textContent = `${currentIR.tempo} bpm · ${currentIR.timeSig?.numerator ?? 4}/${currentIR.timeSig?.denominator ?? 4}`;
+  beatLabel.textContent = "—";
+  renderVoices();
+  setAiStatus("press play to start the loop");
+
+  return {
+    destroy: async () => {
+      await stopLoop();
+    },
+  };
+}
+
+function renderShell(initialVoiceNames) {
+  return `
+    <div class="live-shell">
+      <div class="live-transport">
+        <div class="live-transport-readout">
+          <span class="readout-eyebrow">tempo</span>
+          <span class="readout-value" id="live-tempo">— bpm · 4/4</span>
+        </div>
+        <div class="live-transport-readout">
+          <span class="readout-eyebrow">bar.beat</span>
+          <span class="readout-value live-beat-value" id="live-beat">—</span>
+        </div>
+        <div class="live-transport-buttons">
+          <button id="live-play" class="btn btn-primary live-play-btn">
+            <span class="btn-glyph">▶</span><span class="btn-label">loop</span>
+          </button>
+          <button id="live-stop" class="btn btn-stop">
+            <span class="btn-glyph">■</span><span class="btn-label">stop</span>
+          </button>
+        </div>
+      </div>
+
       <div class="panel-head">
-        <span class="panel-num">LIVE</span>
-        <h2 class="panel-title">performance · coming soon</h2>
-        <span class="status-led status-led--idle" title="awaiting next release"></span>
+        <span class="panel-num">VOICES</span>
+        <h2 class="panel-title">mute · solo · pulse</h2>
+        <span class="status-led status-led--idle"></span>
       </div>
-      <div class="placeholder-grid">
-        ${Array.from({ length: 16 })
-          .map(
-            (_, i) => `<button class="pad" disabled aria-label="pad ${i + 1}">
-              <span class="pad-num">${(i + 1).toString().padStart(2, "0")}</span>
-            </button>`,
-          )
-          .join("")}
+      <div id="live-voices" class="voice-grid"></div>
+
+      <div class="panel-head live-ai-head">
+        <span class="panel-num">SUGGEST</span>
+        <h2 class="panel-title">ask the assistant for a part</h2>
+        <span class="readout" id="live-ai-provider">…</span>
       </div>
-      <p class="placeholder-blurb">
-        loop the current composition · mute, solo, transpose voices on the
-        fly · ask the assistant to drop a fill at the next downbeat ·
-        record performances back into your project.
-      </p>
-      <p class="placeholder-meta">project: <strong>${escapeHtml(project.name)}</strong></p>
+      <div class="live-ai-pane">
+        <textarea
+          id="live-ai-input"
+          class="ai-input"
+          rows="2"
+          placeholder="e.g. 'add a clap on the backbeat' or 'replace the lead with a slower melody'"
+        ></textarea>
+        <div class="ai-buttons">
+          <button id="live-ai-send" class="btn btn-primary">
+            <span class="btn-glyph">▸</span><span class="btn-label">send</span>
+          </button>
+          <button id="live-ai-cancel" class="btn" hidden>
+            <span class="btn-glyph">■</span><span class="btn-label">cancel</span>
+          </button>
+        </div>
+        <p class="ai-status" id="live-ai-status">…</p>
+        <pre id="live-ai-stream" class="ai-stream" hidden></pre>
+        <div id="live-ai-result" class="live-ai-result" hidden></div>
+        <div class="ai-buttons">
+          <button id="live-ai-accept" class="btn btn-primary" hidden>
+            <span class="btn-glyph">✓</span><span class="btn-label">accept · hot-reload</span>
+          </button>
+          <button id="live-ai-reject" class="btn btn-stop" hidden>
+            <span class="btn-glyph">×</span><span class="btn-label">reject</span>
+          </button>
+        </div>
+      </div>
     </div>
   `;
+}
 
-  return { destroy: () => {} };
+function truncatedNote(collected) {
+  return isTruncated(collected)
+    ? `<span class="live-ai-tag live-ai-tag-warn">truncated</span>`
+    : "";
 }
 
 function escapeHtml(s) {

--- a/demo/style.css
+++ b/demo/style.css
@@ -1243,3 +1243,235 @@ body {
   /* No-op: the new shell never renders these wrappers. Old rules above
      still apply when the AI sidebar / editor reuse panel-head class. */
 }
+
+/* ============================================================
+   LIVE MODE
+   ============================================================ */
+
+.live-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.live-error {
+  border: 1px solid var(--rule);
+  padding: 24px 28px;
+  background: var(--bg);
+}
+
+/* ----- Transport bar ---------------------------------------- */
+.live-transport {
+  display: grid;
+  grid-template-columns: auto auto 1fr;
+  align-items: end;
+  gap: 28px;
+  padding: 18px 22px;
+  border: 1px solid var(--rule);
+  background: var(--code-bg);
+  color: var(--code-fg);
+}
+
+.live-transport-readout {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.readout-eyebrow {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+
+.live-transport-readout .readout-value {
+  font-family: var(--font-mono);
+  font-size: 22px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: var(--accent);
+  text-shadow: 0 0 12px rgba(255, 212, 0, 0.18);
+}
+
+.live-beat-value {
+  min-width: 8ch;
+  display: inline-block;
+}
+
+.live-transport-buttons {
+  justify-self: end;
+  display: flex;
+  gap: 8px;
+}
+
+.live-play-btn.is-on {
+  background: var(--accent);
+  color: var(--ink);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(255, 212, 0, 0.2);
+}
+
+/* ----- Voice grid (mute/solo cards) ------------------------- */
+.voice-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 10px;
+}
+
+.voice-card {
+  border: 1px solid var(--rule);
+  background: var(--bg);
+  padding: 14px 14px 12px;
+  display: grid;
+  grid-template-rows: auto auto;
+  gap: 10px;
+  position: relative;
+  transition: background 0.15s ease, border-color 0.15s ease, opacity 0.15s ease;
+}
+
+.voice-card.is-muted {
+  opacity: 0.45;
+  background: var(--bg-tint);
+}
+
+.voice-card.is-solo {
+  border-color: var(--accent);
+  box-shadow: inset 0 0 0 1px var(--accent);
+}
+
+/* Subtle pulse driven by the beat ticker */
+.voice-card-led {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border: 1px solid var(--rule);
+  background: var(--bg);
+  transition: background 0.08s ease, box-shadow 0.08s ease;
+}
+
+.voice-card.is-pulsing .voice-card-led {
+  background: var(--accent);
+  box-shadow: 0 0 0 3px rgba(255, 212, 0, 0.22);
+}
+
+.voice-card.is-pulse-strong .voice-card-led {
+  background: var(--accent-warm);
+  box-shadow: 0 0 0 4px rgba(255, 122, 26, 0.35);
+}
+
+.voice-card-head {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 10px;
+}
+
+.voice-card-name {
+  font-family: var(--font-sans);
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: var(--ink);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.voice-card-meta {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+
+.voice-card-buttons {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+}
+
+.pad-btn {
+  appearance: none;
+  height: 38px;
+  border: 1px solid var(--rule);
+  background: var(--bg-tint);
+  color: var(--ink);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+
+.pad-btn:hover {
+  background: var(--ink);
+  color: var(--bg);
+}
+
+.pad-btn.is-on {
+  background: var(--ink);
+  color: var(--bg);
+}
+
+.pad-btn-solo.is-on {
+  background: var(--accent);
+  color: var(--ink);
+  border-color: var(--accent);
+}
+
+/* ----- Live AI suggest pane --------------------------------- */
+.live-ai-head {
+  align-items: center;
+}
+
+.live-ai-pane {
+  border: 1px solid var(--rule);
+  padding: 18px 20px;
+  background: var(--bg);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.live-ai-result {
+  border: 1px solid var(--rule);
+  padding: 12px 14px;
+  background: var(--bg-tint);
+}
+
+.live-ai-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.live-ai-tag {
+  display: inline-block;
+  padding: 4px 10px;
+  border: 1px solid var(--rule);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.live-ai-tag-replaced {
+  background: var(--accent);
+  color: var(--ink);
+}
+
+.live-ai-tag-added {
+  background: var(--ok);
+  color: var(--bg);
+  border-color: var(--ok);
+}
+
+.live-ai-tag-warn {
+  background: var(--accent-warm);
+  color: var(--ink);
+  border-color: var(--accent-warm);
+}

--- a/src/runtime/composition.ts
+++ b/src/runtime/composition.ts
@@ -1,5 +1,5 @@
 import type { CompositionIR, Diagnostic, TimelineEvent } from "../ir/nodes.js";
-import type { AudioContextLike, AudioNodeLike } from "./audio-context.js";
+import type { AudioContextLike, AudioNodeLike, GainNodeLike } from "./audio-context.js";
 import { type SampleBuffers, type SampleFetcher, preloadSamples } from "./sample-preload.js";
 import { LookaheadScheduler, type SchedulerOptions } from "./scheduler.js";
 import { beatsToSeconds } from "./time.js";
@@ -31,6 +31,11 @@ export class Composition {
   private masterInput: AudioNodeLike | null = null;
   private sampleBuffers: SampleBuffers = new Map();
   private samplesLoaded = false;
+  // Per-voice mute gates — a GainNode sits between every voice's output and
+  // the master bus, so mute/solo flips a single param value with sample
+  // accuracy. No IR swap, no schedule clear, no loop restart needed.
+  private voiceGates: Map<string, GainNodeLike> = new Map();
+  private voiceMuted: Set<string> = new Set();
 
   constructor(
     private readonly ir: CompositionIR,
@@ -90,14 +95,30 @@ export class Composition {
     return headroom;
   }
 
+  /**
+   * Get or create the per-voice mute gate. Each voice routes through a
+   * dedicated GainNode whose value is 1.0 when active and 0.0 when muted —
+   * flipping `setVoiceMuted` is sample-accurate and never needs to
+   * reschedule events.
+   */
+  private getVoiceGate(name: string): GainNodeLike {
+    let gate = this.voiceGates.get(name);
+    if (gate) return gate;
+    gate = this.ctx.createGain();
+    gate.gain.value = this.voiceMuted.has(name) ? 0 : 1;
+    gate.connect(this.getMasterInput());
+    this.voiceGates.set(name, gate);
+    return gate;
+  }
+
   private scheduleIteration(iterStartTime: number, fromBeat = 0): void {
-    const voiceOutput = this.ctx.createGain();
-    voiceOutput.connect(this.getMasterInput());
     for (const voice of this.ir.voices) {
       const filteredVoice = {
         ...voice,
         events: voice.events.filter((e) => e.startBeat >= fromBeat),
       };
+      const voiceOutput = this.ctx.createGain();
+      voiceOutput.connect(this.getVoiceGate(voice.name));
       const player = new VoicePlayer({
         ctx: this.ctx,
         voice: filteredVoice,
@@ -111,6 +132,41 @@ export class Composition {
       });
       player.schedule();
       this.players.push(player);
+    }
+  }
+
+  /**
+   * Mute or unmute a voice in real time. Sample-accurate via the per-voice
+   * gain gate; events keep firing on schedule but produce silence while the
+   * gate is closed. Soloing in callers is "mute every voice that isn't in
+   * the solo set" — implement at the call site.
+   */
+  setVoiceMuted(name: string, muted: boolean): void {
+    if (muted) this.voiceMuted.add(name);
+    else this.voiceMuted.delete(name);
+    const gate = this.voiceGates.get(name);
+    if (!gate) return; // nothing scheduled yet — gate will be created lazily
+    const t = this.ctx.currentTime;
+    gate.gain.cancelScheduledValues(t);
+    gate.gain.setValueAtTime(muted ? 0 : 1, t);
+  }
+
+  /**
+   * Convenience: pass a set of voice names that should remain audible.
+   * When the set is empty, every voice is unmuted. Resolves all known
+   * voices (those that have ever scheduled) plus any in `this.ir.voices`.
+   */
+  setSolo(soloNames: Set<string>): void {
+    const allNames = new Set<string>([
+      ...this.voiceGates.keys(),
+      ...this.ir.voices.map((v) => v.name),
+    ]);
+    if (soloNames.size === 0) {
+      for (const name of allNames) this.setVoiceMuted(name, false);
+      return;
+    }
+    for (const name of allNames) {
+      this.setVoiceMuted(name, !soloNames.has(name));
     }
   }
 
@@ -198,14 +254,9 @@ export class Composition {
     const elapsedSec = this.ctx.currentTime - this.playStartTime;
     const tempo = this.ir.tempo;
     const currentBeat = elapsedSec / (4 * (60 / tempo));
-    // Stop active oscillators (events that have already been dispatched).
+    // Stop active players
     for (const player of this.players) player.stop();
     this.players.length = 0;
-    // Drop every event still pending in the lookahead queue. Loop mode
-    // pre-arms the next iteration's events from the OLD IR ahead of time;
-    // without this, those events would still fire after the swap and
-    // mute/solo changes wouldn't take effect until the loop wrapped.
-    this.scheduler.clearQueue();
     // Swap IR (use unknown cast to bypass readonly)
     (this as unknown as { ir: CompositionIR }).ir = newIR;
     // Re-anchor: reschedule from the *new* IR starting at the current beat

--- a/src/runtime/composition.ts
+++ b/src/runtime/composition.ts
@@ -198,9 +198,14 @@ export class Composition {
     const elapsedSec = this.ctx.currentTime - this.playStartTime;
     const tempo = this.ir.tempo;
     const currentBeat = elapsedSec / (4 * (60 / tempo));
-    // Stop active players
+    // Stop active oscillators (events that have already been dispatched).
     for (const player of this.players) player.stop();
     this.players.length = 0;
+    // Drop every event still pending in the lookahead queue. Loop mode
+    // pre-arms the next iteration's events from the OLD IR ahead of time;
+    // without this, those events would still fire after the swap and
+    // mute/solo changes wouldn't take effect until the loop wrapped.
+    this.scheduler.clearQueue();
     // Swap IR (use unknown cast to bypass readonly)
     (this as unknown as { ir: CompositionIR }).ir = newIR;
     // Re-anchor: reschedule from the *new* IR starting at the current beat

--- a/src/runtime/scheduler.ts
+++ b/src/runtime/scheduler.ts
@@ -71,4 +71,13 @@ export class LookaheadScheduler {
   get pendingCount(): number {
     return this.queue.length;
   }
+
+  /**
+   * Drop every queued event without dispatching it. Used by `Composition.update`
+   * when swapping in a new IR so events pre-armed for an upcoming loop
+   * iteration (built from the old IR) don't fire alongside the new schedule.
+   */
+  clearQueue(): void {
+    this.queue.length = 0;
+  }
 }


### PR DESCRIPTION
## Summary

Phase 2 of the studio plan. Replaces the live-mode placeholder with a working performance surface that loops the current composition, exposes per-voice mute/solo, pulses LEDs on every beat, and lets the musician ask the assistant for a part that hot-reloads into the running loop without stopping playback.

## Built on existing runtime

No new infrastructure — direct re-use of:
- \`Composition.play({ loop: true })\` for the loop
- \`Composition.update(newIR)\` for hot-reload
- \`isolateIR(ir, { voices })\` for mute/solo gating
- \`mergeBlocks\` + \`extractAllDslBlocks\` for AI partial blocks
- \`compileSync\` validation before swapping a proposal in

## UI

- **Transport**: dark screen panel with TE-yellow segmented JetBrains Mono LED readouts (tempo · bar.beat). Loop button glows yellow when active.
- **Voice grid**: one card per voice, mute (M) + solo (S) pad buttons, square LED that pulses yellow on every beat, warm-orange on downbeats. Soloed voices glow yellow, muted voices fade to bg-tint at 45% opacity.
- **Suggest pane**: textarea + send/cancel + provider readout. Same provider auto-detection as compose mode (reads saved Groq key from localStorage). Result tags surface per-block info ("replaced voice X", "added voice Y", warn tag on truncation). Accept hot-reloads + autosaves; reject discards.

## Behavior
- Beat ticker uses \`setInterval(60000/tempo)\` driven by \`performance.now\` to compute bar.beat readout and toggle per-card LEDs in sync; stops cleanly on stop and clears the LEDs.
- Errors surface gracefully — if the project source doesn't compile, live mode renders an inline diagnostic and a hint to switch back to compose mode.
- Shell wires the new \`onSourceChange\` callback into live mode so AI-accepted proposals autosave just like compose-mode edits.

## Test plan
- [x] \`pnpm test\` (863 pass), \`pnpm lint\`, \`pnpm build\`
- [ ] Open demo, switch to live mode, press loop → composition plays repeating, beat LEDs pulse on every voice card
- [ ] Toggle mute on a voice → it drops out without stopping the loop; toggle off → it returns
- [ ] Solo a voice → only it plays; un-solo → all return
- [ ] Send "add a clap on the backbeat" → AI returns a block → accept → clap appears in the loop without restart, autosave fires

## Next
- PR 24 — Review mode: DAW canvas timeline (piano-roll per voice)
- PR 25 — Review mode: VexFlow sheet music
- PR 26 — Polish + per-voice effects sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)